### PR TITLE
permissionsのcontentsをwriteに修正

### DIFF
--- a/.github/workflows/build-and-release-documents.yml
+++ b/.github/workflows/build-and-release-documents.yml
@@ -25,7 +25,7 @@ on:
 
 permissions:
   id-token: write
-  contents: read
+  contents: write
 
 env:
   APP_ALESINFINY_MARIS_WEBAPP_NAME: app-alesinfiny-maris-docs-prod


### PR DESCRIPTION
azure用に追加した余分な設定（修正しても問題なし）によりgithub releaseが権限がなくなり実行できなかったため修正
