### PR TITLE
フロントエンド CI の node.js を 18 にあげる

### DIFF
--- a/.github/workflows/samples-dressca-frontend.ci.yml
+++ b/.github/workflows/samples-dressca-frontend.ci.yml
@@ -21,13 +21,13 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - uses: actions/cache@v3


### PR DESCRIPTION
- node.js : 16 → 18
- actions/setup-node : v3 → v4 