### PR TITLE
vue-createのインストールオプションの記述を修正

### DIFF
--- a/documents/contents/guidebooks/how-to-develop/vue-js/create-vuejs-blank-project.md
+++ b/documents/contents/guidebooks/how-to-develop/vue-js/create-vuejs-blank-project.md
@@ -29,7 +29,7 @@ create-vue パッケージをインストールする必要があり、続行す
 √ Add Vue Router for Single Page Application development? ... Yes
 √ Add Pinia for state management? ... Yes
 √ Add Vitest for Unit Testing? ... Yes
-√ Add Cypress for End-to-End testing? ... Yes
+√ Add an End-to-End Testing Solution? » Cypress
 √ Add ESLint for code quality? ... Yes
 √ Add Prettier for code formatting? ... Yes
 ```


### PR DESCRIPTION
vue-createのE2Eオプションがcypress1択から選択肢が増えたためcypressを指定する表現に修正

```
√ Add Cypress for End-to-End testing? ... Yes
↓
√ Add an End-to-End Testing Solution? » Cypress
```