### PR TITLE
ESLint, Cypressの商標について追記

### DIFF
--- a/documents/contents/about-maris/trademarks.md
+++ b/documents/contents/about-maris/trademarks.md
@@ -39,6 +39,8 @@ BIPROGY 株式会社からの許可がない場合、以下のように使用し
 - 「macOS」は、米国およびその他の国で登録された Apple Inc. の商標です。
   AlesInfiny Maris は、独立したドキュメントであり、 Apple Inc.が認定、後援、その他承認したものではありません。
 - The Tailwind name and logos are trademarks of Tailwind Labs Inc.
+- 「ESLint」およびそのロゴは OpenJS Foundation の商標または登録商標です。
+- 「Cypress」およびそのロゴは Cypress.io, Inc. の商標または登録商標です。
 - その他記載されている会社名・商品名などは、各社の商標および登録商標です。
 - 本サイトに記載の商品名、製品名、社名などには、必ずしも商標表示 ( (R) 、 TM ) を付記していません。
 


### PR DESCRIPTION
# 更新箇所
- `商標`ページに追記