### PR TITLE
vue-tscが内部で依存するvolarを2.3.4にアップデートする

### DIFF
--- a/samples/AzureADB2CAuth/auth-frontend/package-lock.json
+++ b/samples/AzureADB2CAuth/auth-frontend/package-lock.json
@@ -2165,27 +2165,27 @@
       }
     },
     "node_modules/@volar/language-core": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.3.2.tgz",
-      "integrity": "sha512-tx2BCWPpSNEW5fbE4XfERqgTtESHfsh8zoRDtpf3fsiDAPJI+2emqlxz2Dqcb4O0kFZzVnWINDOx/j6j1H3Vgw==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.3.4.tgz",
+      "integrity": "sha512-wXBhY11qG6pCDAqDnbBRFIDSIwbqkWI7no+lj5+L7IlA7HRIjRP7YQLGzT0LF4lS6eHkMSsclXqy9DwYJasZTQ==",
       "dev": true,
       "dependencies": {
-        "@volar/source-map": "2.3.2"
+        "@volar/source-map": "2.3.4"
       }
     },
     "node_modules/@volar/source-map": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.3.2.tgz",
-      "integrity": "sha512-YGQ5UFNj+ngpklp3SNzTHzaq7e5Rqlcb01ym+oR8mtu7BfkfBxmtCv8YNXEVZ/oU6MF8s3cibpZhOn696MRsYg==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.3.4.tgz",
+      "integrity": "sha512-C+t63nwcblqLIVTYXaVi/+gC8NukDaDIQI72J3R7aXGvtgaVB16c+J8Iz7/VfOy7kjYv7lf5GhBny6ACw9fTGQ==",
       "dev": true
     },
     "node_modules/@volar/typescript": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.3.2.tgz",
-      "integrity": "sha512-HJ1mjiEU/R1Wg3lrBp9jqNZvMOkNLA8+ryHhrzHAjV7pv214mQT/mB/1msu3mduh1Q2iDETU4Vttl5RA7ZPezg==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.3.4.tgz",
+      "integrity": "sha512-acCvt7dZECyKcvO5geNybmrqOsu9u8n5XP1rfiYsOLYGPxvHRav9BVmEdRyZ3vvY6mNyQ1wLL5Hday4IShe17w==",
       "dev": true,
       "dependencies": {
-        "@volar/language-core": "2.3.2",
+        "@volar/language-core": "2.3.4",
         "path-browserify": "^1.0.1",
         "vscode-uri": "^3.0.8"
       }
@@ -6588,38 +6588,17 @@
         "typescript": "*"
       }
     },
-    "node_modules/vue-tsc/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/vue-tsc/node_modules/semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
       "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
       "bin": {
         "semver": "bin/semver.js"
       },
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/vue-tsc/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",

--- a/samples/Dressca/dressca-frontend/package-lock.json
+++ b/samples/Dressca/dressca-frontend/package-lock.json
@@ -2419,27 +2419,27 @@
       }
     },
     "node_modules/@volar/language-core": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.3.2.tgz",
-      "integrity": "sha512-tx2BCWPpSNEW5fbE4XfERqgTtESHfsh8zoRDtpf3fsiDAPJI+2emqlxz2Dqcb4O0kFZzVnWINDOx/j6j1H3Vgw==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.3.4.tgz",
+      "integrity": "sha512-wXBhY11qG6pCDAqDnbBRFIDSIwbqkWI7no+lj5+L7IlA7HRIjRP7YQLGzT0LF4lS6eHkMSsclXqy9DwYJasZTQ==",
       "dev": true,
       "dependencies": {
-        "@volar/source-map": "2.3.2"
+        "@volar/source-map": "2.3.4"
       }
     },
     "node_modules/@volar/source-map": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.3.2.tgz",
-      "integrity": "sha512-YGQ5UFNj+ngpklp3SNzTHzaq7e5Rqlcb01ym+oR8mtu7BfkfBxmtCv8YNXEVZ/oU6MF8s3cibpZhOn696MRsYg==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.3.4.tgz",
+      "integrity": "sha512-C+t63nwcblqLIVTYXaVi/+gC8NukDaDIQI72J3R7aXGvtgaVB16c+J8Iz7/VfOy7kjYv7lf5GhBny6ACw9fTGQ==",
       "dev": true
     },
     "node_modules/@volar/typescript": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.3.2.tgz",
-      "integrity": "sha512-HJ1mjiEU/R1Wg3lrBp9jqNZvMOkNLA8+ryHhrzHAjV7pv214mQT/mB/1msu3mduh1Q2iDETU4Vttl5RA7ZPezg==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.3.4.tgz",
+      "integrity": "sha512-acCvt7dZECyKcvO5geNybmrqOsu9u8n5XP1rfiYsOLYGPxvHRav9BVmEdRyZ3vvY6mNyQ1wLL5Hday4IShe17w==",
       "dev": true,
       "dependencies": {
-        "@volar/language-core": "2.3.2",
+        "@volar/language-core": "2.3.4",
         "path-browserify": "^1.0.1",
         "vscode-uri": "^3.0.8"
       }
@@ -9484,38 +9484,17 @@
         "typescript": "*"
       }
     },
-    "node_modules/vue-tsc/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/vue-tsc/node_modules/semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
       "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
       "bin": {
         "semver": "bin/semver.js"
       },
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/vue-tsc/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",


### PR DESCRIPTION
# 概要
vue-tscが内部で依存するvolarの2.3.2に不具合があり、型チェックがエラーになる現象が発生しているので、
不具合解消済みのlatestバージョンへアップデートを行う。

# 確認ポイント
DresscaとAzureADB2CAuthのサンプルアプリについて、
1. npm installを行う
2. npm run typecheck を実行する
    - 正常に動作することを確認