### PR TITLE
GitHub APIのレート制限によるワークフロー失敗を対策する（リトライ・時間変更）

### DIFF
--- a/.github/workflows/check-openapi-generator-update.yml
+++ b/.github/workflows/check-openapi-generator-update.yml
@@ -6,7 +6,7 @@ on:
       - '.github/workflows/check-openapi-generator-update.yml'
   workflow_dispatch:
   schedule:
-    - cron: '0 0 * * 1'
+    - cron: '0 22 * * 0'
 permissions:
   contents: read
   issues: write
@@ -66,7 +66,7 @@ jobs:
             update_existing: true
             search_existing: open
           attempt_limit: 3
-          attempt_delay: 60000
+          attempt_delay: 300000
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LATEST_VERSION: ${{ steps.get-latest-openapi-generator-version.outputs.latest-version }}


### PR DESCRIPTION
# 変更点
- issueの作成について、5分間隔で3回まで試行するように修正しました。
- 起動時刻を日本時間の月曜7時（世界標準時の日曜22時）に変更いたしました。

# リトライ発生時の実行例
- 下記の実行例でのリトライ間隔は1分になっております。
>https://github.com/AlesInfiny/maris/actions/runs/9949744215/job/27486478096