### PR TITLE
CatalogDomainServiceTestのテストが稀に失敗する問題に対処する

### DIFF
--- a/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.ApplicationCore/Catalog/CatalogDomainServiceTest.cs
+++ b/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.ApplicationCore/Catalog/CatalogDomainServiceTest.cs
@@ -136,8 +136,8 @@ public class CatalogDomainServiceTest(ITestOutputHelper testOutputHelper) : Test
     private static CatalogItem CreateCatalogItem(long id)
     {
         var random = new Random();
-        long defaultCatalogCategoryId = random.NextInt64(1000L);
-        long defaultCatalogBrandId = random.NextInt64(1000L);
+        long defaultCatalogCategoryId = random.NextInt64(1L, 1000L);
+        long defaultCatalogBrandId = random.NextInt64(1L, 1000L);
         const string defaultDescription = "Description.";
         const string defaultName = "Name";
         const decimal defaultPrice = 100m;


### PR DESCRIPTION
#### PR Classification
ランダム値生成方法の変更

#### PR Summary
`CreateCatalogItem`メソッド内でランダム値生成範囲を変更しました。
- `defaultCatalogCategoryId`と`defaultCatalogBrandId`の生成方法を`random.NextInt64(1L, 1000L)`に変更し、1から999の範囲のランダムな値を生成するようにしました。
