### PR TITLE
vite@5.4.6にアップデートする

### DIFF
--- a/samples/AzureADB2CAuth/auth-frontend/package-lock.json
+++ b/samples/AzureADB2CAuth/auth-frontend/package-lock.json
@@ -35,7 +35,7 @@
         "npm-run-all2": "^6.2.3",
         "prettier": "^3.3.3",
         "typescript": "~5.6.2",
-        "vite": "^5.3.5",
+        "vite": "^5.4.6",
         "vitest": "^2.1.1",
         "vue-tsc": "^2.1.6"
       }
@@ -8109,14 +8109,14 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/vite": {
-      "version": "5.3.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.3.5.tgz",
-      "integrity": "sha512-MdjglKR6AQXQb9JGiS7Rc2wC6uMjcm7Go/NHNO63EwiJXfuk9PgqiP/n5IDJCziMkfw9n4Ubp7lttNwz+8ZVKA==",
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.6.tgz",
+      "integrity": "sha512-IeL5f8OO5nylsgzd9tq4qD2QqI0k2CQLGrWD0rCN0EQJZpBK5vJAx0I+GDkMOXxQX/OfFHMuLIx6ddAxGX/k+Q==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.21.3",
-        "postcss": "^8.4.39",
-        "rollup": "^4.13.0"
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -8135,6 +8135,7 @@
         "less": "*",
         "lightningcss": "^1.21.0",
         "sass": "*",
+        "sass-embedded": "*",
         "stylus": "*",
         "sugarss": "*",
         "terser": "^5.4.0"
@@ -8150,6 +8151,9 @@
           "optional": true
         },
         "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
           "optional": true
         },
         "stylus": {

--- a/samples/AzureADB2CAuth/auth-frontend/package.json
+++ b/samples/AzureADB2CAuth/auth-frontend/package.json
@@ -45,7 +45,7 @@
     "npm-run-all2": "^6.2.3",
     "prettier": "^3.3.3",
     "typescript": "~5.6.2",
-    "vite": "^5.3.5",
+    "vite": "^5.4.6",
     "vitest": "^2.1.1",
     "vue-tsc": "^2.1.6"
   }


### PR DESCRIPTION
dependabotのPRが最新版の5.4.8を対象としていますが、
Dresscaと同じ5.4.6までのアップデートを行いたいため、
手動でPRを作成してセルフマージします。