### PR TITLE
typescript@5.4.5にバージョンを戻す

### DIFF
--- a/samples/AzureADB2CAuth/auth-frontend/package-lock.json
+++ b/samples/AzureADB2CAuth/auth-frontend/package-lock.json
@@ -34,7 +34,7 @@
         "jsdom": "^25.0.1",
         "npm-run-all2": "^6.2.3",
         "prettier": "^3.3.3",
-        "typescript": "~5.6.2",
+        "typescript": "~5.4.5",
         "vite": "^5.4.6",
         "vitest": "^2.1.1",
         "vue-tsc": "^2.1.6"
@@ -8013,9 +8013,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
-      "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/samples/AzureADB2CAuth/auth-frontend/package.json
+++ b/samples/AzureADB2CAuth/auth-frontend/package.json
@@ -44,7 +44,7 @@
     "jsdom": "^25.0.1",
     "npm-run-all2": "^6.2.3",
     "prettier": "^3.3.3",
-    "typescript": "~5.6.2",
+    "typescript": "~5.4.5",
     "vite": "^5.4.6",
     "vitest": "^2.1.1",
     "vue-tsc": "^2.1.6"


### PR DESCRIPTION
# 概要
Dresscaと同じtypescript@5.4.5に揃えるようにバージョンを戻します。
アップデート時のコミットのrevertを試みたところコンフリクトしたため、
npm install typescript@~5.4.5
を実行してダウングレードしました。

# 確認した点
- package-lock.jsonの差分がtypescriptのみであること
- アプリケーションが正常に動作すること（稼働確認）