### PR TITLE
mermaidの表示バグを避けるためにmkdocs-materialを9.5.33にダウングレードする

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 yamllint==1.35.1
 mkdocs==1.6.1
-mkdocs-material==9.5.39
+mkdocs-material==9.5.33
 pymdown-extensions==10.11.2
 mkdocs-minify-plugin==0.8.0
 mkdocs-rss-plugin==1.15.0


### PR DESCRIPTION
## このプルリクエストで実施したこと
mkdocs-materialのバージョンを9.5.33にダウングレードします。

### 目的
mkdocs-material@9.5.34にて、mermaid11系へのアップグレードが行われましたが、
mermaid11系では下記の箇所の図が正しく表示されないため、
正しく表示されるバージョンまでダウングレードします。

### 確認した点
ローカル環境で該当の図が正しく表示されること。

## このプルリクエストでは実施していないこと
なし

## Issue や Discussions 、関連する Web サイトなどへのリンク

### 該当する図
https://maris.alesinfiny.org/app-architecture/overview/configuration-management/#branch-strategy
![image](https://github.com/user-attachments/assets/26cf52c6-35e8-4081-9734-868be34a195c)

### mkdocs-materialのリリースノート
https://github.com/squidfunk/mkdocs-material/releases/tag/9.5.34

### mermaidの不具合報告
https://github.com/mermaid-js/mermaid/issues/5898