### PR TITLE
コーディング規約のメニュー表示位置を暫定的に一段上に変更

### DIFF
--- a/documents/mkdocs.yml
+++ b/documents/mkdocs.yml
@@ -95,8 +95,8 @@ nav:
           # - アプリケーションテスト:
               # - guidebooks/app-testing/index.md
       # - 規約:
-      #     - guidebooks/conventions/index.md
-          - コーディング規約: guidebooks/conventions/coding-conventions.md
+      #     - guidebooks/conventions/index.md このページができるまで、コーディング規約を一段上のメニューに配置している。
+      - コーディング規約: guidebooks/conventions/coding-conventions.md
       - マイグレーション:
           - guidebooks/migration/index.md
           - .NET Framework にとどまることのリスク:


### PR DESCRIPTION
## このプルリクエストで実施したこと

コーディング規約のメニューの位置を一段上位に移動しました。
ローカルでの確認結果は以下のとおりです。

![image](https://github.com/user-attachments/assets/64198375-2a8d-41d5-a76a-1a4a4c2c7ec1)

規約が増えたら、「規約」をガイドのメニューに追加し、コーディング規約のメニューを「規約」の下に移動する想定です。

## このプルリクエストでは実施していないこと

なし

## Issue や Discussions 、関連する Web サイトなどへのリンク

なし
