### PR TITLE
サンプルアプリの起動手順をワークスペース用に変更する

### DIFF
--- a/documents/contents/index.md
+++ b/documents/contents/index.md
@@ -49,7 +49,7 @@ AlesInfiny Maris で構築した Web アプリケーションのサンプルを�
     !!! info "npm ci が失敗した場合"
         `npm ci` の途中でエラーや脆弱性情報以外の警告が出た場合、インストールに失敗している可能性があります。
         その場合は、「dressca\\dressca-frontend\\node_modules」、
-        「dressca\\dressca-frontend\\consumer\\node_modules」ディレクトリをそれぞれ削除し、再度 `npm ci` を実行してください。
+        「dressca\\dressca-frontend\\consumer\\node_modules」フォルダーをそれぞれ削除し、再度 `npm ci` を実行してください。
 
 1. Visual Studio で「dressca\\dressca-backend\\Dressca.sln」を開き、ソリューションをビルドします。
 


### PR DESCRIPTION
## このプルリクエストで実施したこと
既存のサンプルアプリDresscaを、consumerワークスペースに移動したことによる、
サンプルアプリの起動手順への影響について、
ドキュメントの修正が漏れていたため、手順を修正いたします。

1. `npm ci`コマンドの実行に失敗した際は、ルートプロジェクト直下とワークスペース配下の両方のnode_modulesを削除してから再実行する手順に修正いたしました。

## このプルリクエストでは実施していないこと
Maris側はVisual Studio経由でバックエンドのプロジェクトの設定に記載のコマンド経由でフロントエンドアプリを起動するため、Maiaと異なり`npm run dev`を実行するためのカレントディレクトリの移動はありません。

AzureADB2Cについてはnpm workspacesをまだ導入していないため、
こちらのREAME.mdについては修正しておりません。

## Issue や Discussions 、関連する Web サイトなどへのリンク
下記のMaia側の修正と同様の修正です。
- https://github.com/AlesInfiny/maia/pull/1395