### PR TITLE
CODE_OF_CONDUCT.mdにcspellの無視リストを追加

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -92,3 +92,4 @@ Contributor Covenant は [Creative Commons Attribution 4.0 International Public 
 
 <!-- textlint-enable @textlint-rule/require-header-id, ja-technical-writing/sentence-length, @textlint-ja/no-synonyms, ja-technical-writing/max-ten, ja-technical-writing/no-doubled-joshi, ja-spacing/ja-space-between-half-and-full-width, ja-spacing/ja-space-around-link, ja-technical-writing/ja-no-mixed-period -->
 <!-- markdownlint-enable CMD001 -->
+<!-- cspell:ignore joshi -->


### PR DESCRIPTION
## この Pull request で実施したこと

cspellの警告となった「joshi」をページ内の無視ワードとして追加しました。
「joshi」はtextlintのルール名に含まれるワードであり、除外することが適当と判断しました。
ただ、全体で許可するワードではないため、ページ単位での除外としています。

## この Pull request では実施していないこと

cspell.json（全体の設定ファイル）への追加は行っていません。

## Issues や Discussions 、関連する Web サイトなどへのリンク

#726
#1320