### PR TITLE
型チェックのコマンドの綴りをtypecheckからtype-checkに変更

### DIFF
--- a/documents/contents/guidebooks/how-to-develop/vue-js/project-settings.md
+++ b/documents/contents/guidebooks/how-to-develop/vue-js/project-settings.md
@@ -137,7 +137,7 @@ Project Reference 機能については [Project References :material-open-in-ne
           "scripts": {
             "build": "run-p type-check \"build-only {@}\" --",
             "build-only": "vite build",
-            "typecheck": "vue-tsc --build --force"
+            "type-check": "vue-tsc --build --force"
           }
         }
         ```

--- a/samples/AzureADB2CAuth/auth-frontend/.vscode/settings.json
+++ b/samples/AzureADB2CAuth/auth-frontend/.vscode/settings.json
@@ -30,7 +30,6 @@
     "pinia",
     "rushstack",
     "stylelint",
-    "typecheck",
     "vite"
   ]
 }


### PR DESCRIPTION
## この Pull request で実施したこと

型チェックのコマンドの綴りをtypecheckからtype-checkに変更した際、
修正が漏れていた下記の箇所についてtype-checkに修正いたしました。
- ドキュメント上のサンプルコード
- cspellの除外設定

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

過去、create-vueのテンプレートはtypecheckでしたが、
create-vue側でのテンプレートもtype-checkに変更済みのため、type-checkに修正しました。