### PR TITLE
WebサイトからGitHubリポジトリにリンクする

### DIFF
--- a/documents/mkdocs.yml
+++ b/documents/mkdocs.yml
@@ -9,6 +9,7 @@ site_description: "AlesInfiny Maris OSS Edition のポータルサイトです�
 site_dir: build-artifacts
 repo_name: AlesInfiny/maris
 repo_url: https://github.com/AlesInfiny/maris
+edit_uri: edit/main/documents/contents/
 
 # yamllint disable rule:comments-indentation
 nav:
@@ -126,6 +127,7 @@ theme:
   custom_dir: overrides
   favicon: assets/images/favicon.png
   features:
+    - content.action.view
     - content.code.annotate
     - navigation.indexes
     - navigation.instant
@@ -137,6 +139,7 @@ theme:
     code: Source Code Pro
   icon:
     repo: fontawesome/brands/github
+    view: material/eye
   language: ja
   logo: assets/maris-logo.png
   palette:


### PR DESCRIPTION
## この Pull request で実施したこと

ヘッダー部にGitHubリポジトリへのリンクを追加しました。
各ページの右上にGitHubのRawページへのリンクを追加しました。

<img width="710" alt="image" src="https://github.com/user-attachments/assets/bdc7c31e-5029-4767-99d9-abde64fd53e5">

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

- <https://squidfunk.github.io/mkdocs-material/setup/adding-a-git-repository/#repository>
- <https://github.com/AlesInfiny/maris/issues/1029>
