### PR TITLE
dependabotでNuGetのSTSバージョン（9, 11）を無視する設定を追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -67,6 +67,13 @@ updates:
       nswag-packages:
         patterns:
           - "NSwag*"
+    ignore:
+      - dependency-name: "Microsoft.AspNetCore*"
+        versions: ["9.*", "11.*"]
+      - dependency-name: "Microsoft.EntityFrameworkCore*"
+        versions: ["9.*", "11.*"]
+      - dependency-name: "Microsoft.Extensions*"
+        versions: ["9.*", "11.*"]
 
   - package-ecosystem: "nuget"
     directory: "/samples/ConsoleAppWithDI/solution"
@@ -87,6 +94,11 @@ updates:
       xunit-packages:
         patterns:
           - "xunit*"
+    ignore:
+      - dependency-name: "Microsoft.EntityFrameworkCore*"
+        versions: ["9.*", "11.*"]
+      - dependency-name: "Microsoft.Extensions*"
+        versions: ["9.*", "11.*"]
 
   - package-ecosystem: "npm"
     directory: "/samples/AzureADB2CAuth/auth-frontend"
@@ -122,3 +134,8 @@ updates:
       nswag-packages:
         patterns:
           - "NSwag*"
+    ignore:
+      - dependency-name: "Microsoft.AspNetCore*"
+        versions: ["9.*", "11.*"]
+      - dependency-name: "Microsoft.Extensions*"
+        versions: ["9.*", "11.*"]


### PR DESCRIPTION
## この Pull request で実施したこと

dependabotによってv9およびv11のNuGetのパッケージ更新を行わないよう設定を追加しました。

## この Pull request では実施していないこと

直近2バージョン分の設定のみ行っています。
STSのバージョンが進めば、設定を見直す必要があります。

## Issues や Discussions 、関連する Web サイトなどへのリンク

- [dependabot.yml ファイルの構成オプション | ignore](https://docs.github.com/ja/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#ignore)