### PR TITLE
メソッド名の ByAdmin を ForAdmin に変更

### DIFF
--- a/samples/Dressca/dressca-backend/src/Dressca.ApplicationCore/ApplicationService/CatalogApplicationService.cs
+++ b/samples/Dressca/dressca-backend/src/Dressca.ApplicationCore/ApplicationService/CatalogApplicationService.cs
@@ -277,9 +277,9 @@ public class CatalogApplicationService
     /// <param name="cancellationToken">キャンセルトークン。</param>
     /// <returns>カタログページと総アイテム数のタプルを返す非同期処理を表すタスク。</returns>
     /// <exception cref="PermissionDeniedException">更新権限がない場合。</exception>
-    public async Task<(IReadOnlyList<CatalogItem> ItemsOnPage, int TotalItems)> GetCatalogItemsByAdminAsync(int skip, int take, long? brandId, long? categoryId, CancellationToken cancellationToken = default)
+    public async Task<(IReadOnlyList<CatalogItem> ItemsOnPage, int TotalItems)> GetCatalogItemsForAdminAsync(int skip, int take, long? brandId, long? categoryId, CancellationToken cancellationToken = default)
     {
-        this.logger.LogDebug(Events.DebugEvent, LogMessages.CatalogApplicationService_GetCatalogItemsByAdminAsyncStart, brandId, categoryId);
+        this.logger.LogDebug(Events.DebugEvent, LogMessages.CatalogApplicationService_GetCatalogItemsForAdminAsyncStart, brandId, categoryId);
 
         if (!this.userStore.IsInRole(Roles.Admin))
         {
@@ -298,7 +298,7 @@ public class CatalogApplicationService
             scope.Complete();
         }
 
-        this.logger.LogDebug(Events.DebugEvent, LogMessages.CatalogApplicationService_GetCatalogItemsByAdminAsyncEnd, brandId, categoryId);
+        this.logger.LogDebug(Events.DebugEvent, LogMessages.CatalogApplicationService_GetCatalogItemsForAdminAsyncEnd, brandId, categoryId);
         return (ItemsOnPage: itemsOnPage, TotalItems: totalItems);
     }
 
@@ -310,9 +310,9 @@ public class CatalogApplicationService
     /// <returns>カタログアイテム。</returns>
     /// <exception cref="PermissionDeniedException">更新権限がない場合。</exception>
     /// <exception cref="CatalogItemNotExistingInRepositoryException">取得対象のカタログアイテムが存在しなかった場合。</exception>
-    public async Task<CatalogItem?> GetCatalogItemByAdminAsync(long catalogItemId, CancellationToken cancellationToken = default)
+    public async Task<CatalogItem?> GetCatalogItemForAdminAsync(long catalogItemId, CancellationToken cancellationToken = default)
     {
-        this.logger.LogDebug(Events.DebugEvent, LogMessages.CatalogApplicationService_GetCatalogItemByAdminAsyncStart, catalogItemId);
+        this.logger.LogDebug(Events.DebugEvent, LogMessages.CatalogApplicationService_GetCatalogItemForAdminAsyncStart, catalogItemId);
 
         if (!this.userStore.IsInRole(Roles.Admin))
         {
@@ -332,7 +332,7 @@ public class CatalogApplicationService
             scope.Complete();
         }
 
-        this.logger.LogDebug(Events.DebugEvent, LogMessages.CatalogApplicationService_GetCatalogItemByAdminAsyncEnd, catalogItemId);
+        this.logger.LogDebug(Events.DebugEvent, LogMessages.CatalogApplicationService_GetCatalogItemForAdminAsyncEnd, catalogItemId);
         return catalogItem;
     }
 }

--- a/samples/Dressca/dressca-backend/src/Dressca.ApplicationCore/Resources/LogMessages.Designer.cs
+++ b/samples/Dressca/dressca-backend/src/Dressca.ApplicationCore/Resources/LogMessages.Designer.cs
@@ -126,18 +126,18 @@ namespace Dressca.ApplicationCore.Resources {
         /// <summary>
         ///   管理者がカタログアイテム ID: {CatalogItemId} のカタログアイテムを取得しました。 に類似しているローカライズされた文字列を検索します。
         /// </summary>
-        internal static string CatalogApplicationService_GetCatalogItemByAdminAsyncEnd {
+        internal static string CatalogApplicationService_GetCatalogItemForAdminAsyncEnd {
             get {
-                return ResourceManager.GetString("CatalogApplicationService_GetCatalogItemByAdminAsyncEnd", resourceCulture);
+                return ResourceManager.GetString("CatalogApplicationService_GetCatalogItemForAdminAsyncEnd", resourceCulture);
             }
         }
         
         /// <summary>
         ///   管理者がカタログアイテム ID: {CatalogItemId} のカタログアイテムを取得します。 に類似しているローカライズされた文字列を検索します。
         /// </summary>
-        internal static string CatalogApplicationService_GetCatalogItemByAdminAsyncStart {
+        internal static string CatalogApplicationService_GetCatalogItemForAdminAsyncStart {
             get {
-                return ResourceManager.GetString("CatalogApplicationService_GetCatalogItemByAdminAsyncStart", resourceCulture);
+                return ResourceManager.GetString("CatalogApplicationService_GetCatalogItemForAdminAsyncStart", resourceCulture);
             }
         }
         
@@ -162,18 +162,18 @@ namespace Dressca.ApplicationCore.Resources {
         /// <summary>
         ///   管理者がカタログブランド ID: {CatalogBrandId} 、カタログカテゴリ ID: {CatalogCategoryId} のカタログ情報を取得しました。 に類似しているローカライズされた文字列を検索します。
         /// </summary>
-        internal static string CatalogApplicationService_GetCatalogItemsByAdminAsyncEnd {
+        internal static string CatalogApplicationService_GetCatalogItemsForAdminAsyncEnd {
             get {
-                return ResourceManager.GetString("CatalogApplicationService_GetCatalogItemsByAdminAsyncEnd", resourceCulture);
+                return ResourceManager.GetString("CatalogApplicationService_GetCatalogItemsForAdminAsyncEnd", resourceCulture);
             }
         }
         
         /// <summary>
         ///   管理者がカタログブランド ID: {CatalogBrandId} 、カタログカテゴリ ID: {CatalogCategoryId} のカタログ情報を取得します。 に類似しているローカライズされた文字列を検索します。
         /// </summary>
-        internal static string CatalogApplicationService_GetCatalogItemsByAdminAsyncStart {
+        internal static string CatalogApplicationService_GetCatalogItemsForAdminAsyncStart {
             get {
-                return ResourceManager.GetString("CatalogApplicationService_GetCatalogItemsByAdminAsyncStart", resourceCulture);
+                return ResourceManager.GetString("CatalogApplicationService_GetCatalogItemsForAdminAsyncStart", resourceCulture);
             }
         }
         

--- a/samples/Dressca/dressca-backend/src/Dressca.ApplicationCore/Resources/LogMessages.resx
+++ b/samples/Dressca/dressca-backend/src/Dressca.ApplicationCore/Resources/LogMessages.resx
@@ -138,10 +138,10 @@
   <data name="CatalogApplicationService_DeleteItemFromCatalogAsyncStart" xml:space="preserve">
     <value>カタログアイテム ID: {CatalogItemId} のカタログアイテムを削除します。</value>
   </data>
-  <data name="CatalogApplicationService_GetCatalogItemByAdminAsyncEnd" xml:space="preserve">
+  <data name="CatalogApplicationService_GetCatalogItemForAdminAsyncEnd" xml:space="preserve">
     <value>管理者がカタログアイテム ID: {CatalogItemId} のカタログアイテムを取得しました。</value>
   </data>
-  <data name="CatalogApplicationService_GetCatalogItemByAdminAsyncStart" xml:space="preserve">
+  <data name="CatalogApplicationService_GetCatalogItemForAdminAsyncStart" xml:space="preserve">
     <value>管理者がカタログアイテム ID: {CatalogItemId} のカタログアイテムを取得します。</value>
   </data>
   <data name="CatalogApplicationService_GetCatalogItemsAsyncEnd" xml:space="preserve">
@@ -150,10 +150,10 @@
   <data name="CatalogApplicationService_GetCatalogItemsAsyncStart" xml:space="preserve">
     <value>カタログブランド ID: {CatalogBrandId} 、カタログカテゴリ ID: {CatalogCategoryId} のカテゴリ情報を取得します。</value>
   </data>
-  <data name="CatalogApplicationService_GetCatalogItemsByAdminAsyncEnd" xml:space="preserve">
+  <data name="CatalogApplicationService_GetCatalogItemsForAdminAsyncEnd" xml:space="preserve">
     <value>管理者がカタログブランド ID: {CatalogBrandId} 、カタログカテゴリ ID: {CatalogCategoryId} のカタログ情報を取得しました。</value>
   </data>
-  <data name="CatalogApplicationService_GetCatalogItemsByAdminAsyncStart" xml:space="preserve">
+  <data name="CatalogApplicationService_GetCatalogItemsForAdminAsyncStart" xml:space="preserve">
     <value>管理者がカタログブランド ID: {CatalogBrandId} 、カタログカテゴリ ID: {CatalogCategoryId} のカタログ情報を取得します。</value>
   </data>
   <data name="CatalogApplicationService_UpdateCatalogItemAsyncEnd" xml:space="preserve">

--- a/samples/Dressca/dressca-backend/src/Dressca.Web.Admin/Controllers/CatalogItemsController.cs
+++ b/samples/Dressca/dressca-backend/src/Dressca.Web.Admin/Controllers/CatalogItemsController.cs
@@ -72,7 +72,7 @@ public class CatalogItemsController : ControllerBase
 
         try
         {
-            catalogItem = await this.service.GetCatalogItemByAdminAsync(catalogItemId);
+            catalogItem = await this.service.GetCatalogItemForAdminAsync(catalogItemId);
         }
         catch (PermissionDeniedException ex)
         {
@@ -114,7 +114,7 @@ public class CatalogItemsController : ControllerBase
         try
         {
             itemsAndCount =
-            await this.service.GetCatalogItemsByAdminAsync(
+            await this.service.GetCatalogItemsForAdminAsync(
                 skip: query.GetSkipCount(),
                 take: query.PageSize,
                 brandId: query.BrandId,

--- a/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.ApplicationCore/ApplicationService/CatalogApplicationServiceTest.cs
+++ b/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.ApplicationCore/ApplicationService/CatalogApplicationServiceTest.cs
@@ -618,7 +618,7 @@ public class CatalogApplicationServiceTest(ITestOutputHelper testOutputHelper) :
     }
 
     [Fact]
-    public async Task GetCatalogItemsByAdminAsync_リポジトリのFindAsyncを一度だけ呼び出す()
+    public async Task GetCatalogItemsForAdminAsync_リポジトリのFindAsyncを一度だけ呼び出す()
     {
         // Arrange
         var catalogRepositoryMock = new Mock<ICatalogRepository>();
@@ -635,7 +635,7 @@ public class CatalogApplicationServiceTest(ITestOutputHelper testOutputHelper) :
         var targetCategoryId = 1;
 
         // Act
-        _ = await service.GetCatalogItemsByAdminAsync(skip, take, targetBrandId, targetCategoryId);
+        _ = await service.GetCatalogItemsForAdminAsync(skip, take, targetBrandId, targetCategoryId);
 
         // Assert
         catalogRepositoryMock.Verify(
@@ -644,7 +644,7 @@ public class CatalogApplicationServiceTest(ITestOutputHelper testOutputHelper) :
     }
 
     [Fact]
-    public async Task GetCatalogItemsByAdminAsync_リポジトリのCountAsyncを1回呼出す()
+    public async Task GetCatalogItemsForAdminAsync_リポジトリのCountAsyncを1回呼出す()
     {
         // Arrange
         var catalogRepositoryMock = new Mock<ICatalogRepository>();
@@ -661,7 +661,7 @@ public class CatalogApplicationServiceTest(ITestOutputHelper testOutputHelper) :
         var targetCategoryId = 1;
 
         // Act
-        _ = await service.GetCatalogItemsByAdminAsync(skip, take, targetBrandId, targetCategoryId);
+        _ = await service.GetCatalogItemsForAdminAsync(skip, take, targetBrandId, targetCategoryId);
 
         // Assert
         catalogRepositoryMock.Verify(
@@ -670,7 +670,7 @@ public class CatalogApplicationServiceTest(ITestOutputHelper testOutputHelper) :
     }
 
     [Fact]
-    public async Task GetCatalogItemsByAdminAsync_ページネーションされたアイテムと総アイテム数が返却される()
+    public async Task GetCatalogItemsForAdminAsync_ページネーションされたアイテムと総アイテム数が返却される()
     {
         // Arrange
         var skip = 0;
@@ -693,7 +693,7 @@ public class CatalogApplicationServiceTest(ITestOutputHelper testOutputHelper) :
         var service = new CatalogApplicationService(catalogRepositoryMock.Object, catalogBrandRepositoryMock.Object, catalogCategoryRepositoryMock.Object, userStoreMock.Object, catalogDomainServiceMock, logger);
 
         // Act
-        var (list, totalItems) = await service.GetCatalogItemsByAdminAsync(skip, take, targetBrandId, targetCategoryId);
+        var (list, totalItems) = await service.GetCatalogItemsForAdminAsync(skip, take, targetBrandId, targetCategoryId);
 
         // Assert
         Assert.Equal(targetItems, list);
@@ -701,7 +701,7 @@ public class CatalogApplicationServiceTest(ITestOutputHelper testOutputHelper) :
     }
 
     [Fact]
-    public async Task GetCatalogItemsByAdminAsync_権限なし_PermissionDeniedExceptionが発生()
+    public async Task GetCatalogItemsForAdminAsync_権限なし_PermissionDeniedExceptionが発生()
     {
         // Arrange
         var catalogRepositoryMock = new Mock<ICatalogRepository>();
@@ -718,14 +718,14 @@ public class CatalogApplicationServiceTest(ITestOutputHelper testOutputHelper) :
         var targetCategoryId = 1;
 
         // Act
-        var action = () => service.GetCatalogItemsByAdminAsync(skip, take, targetBrandId, targetCategoryId);
+        var action = () => service.GetCatalogItemsForAdminAsync(skip, take, targetBrandId, targetCategoryId);
 
         // Assert
         await Assert.ThrowsAsync<PermissionDeniedException>(action);
     }
 
     [Fact]
-    public async Task GetCatalogItemByAdminAsync_リポジトリのGetAsyncを一度だけ呼び出す()
+    public async Task GetCatalogItemForAdminAsync_リポジトリのGetAsyncを一度だけ呼び出す()
     {
         // Arrange
         var targetId = 1;
@@ -743,14 +743,14 @@ public class CatalogApplicationServiceTest(ITestOutputHelper testOutputHelper) :
         var service = new CatalogApplicationService(catalogRepositoryMock.Object, catalogBrandRepository, catalogCategoryRepository, userStoreMock.Object, catalogDomainServiceMock, logger);
 
         // Act
-        _ = await service.GetCatalogItemByAdminAsync(targetId);
+        _ = await service.GetCatalogItemForAdminAsync(targetId);
 
         // Assert
         catalogRepositoryMock.Verify(r => r.GetAsync(targetId, AnyToken), Times.Once);
     }
 
     [Fact]
-    public async Task GetCatalogItemByAdminAsync_権限なし_PermissionDeniedExceptionが発生()
+    public async Task GetCatalogItemForAdminAsync_権限なし_PermissionDeniedExceptionが発生()
     {
         // Arrange
         var targetId = 1;
@@ -768,14 +768,14 @@ public class CatalogApplicationServiceTest(ITestOutputHelper testOutputHelper) :
         var service = new CatalogApplicationService(catalogRepositoryMock.Object, catalogBrandRepository, catalogCategoryRepository, userStoreMock.Object, catalogDomainServiceMock, logger);
 
         // Act
-        var action = () => service.GetCatalogItemByAdminAsync(targetId);
+        var action = () => service.GetCatalogItemForAdminAsync(targetId);
 
         // Assert
         await Assert.ThrowsAsync<PermissionDeniedException>(action);
     }
 
     [Fact]
-    public async Task GetCatalogItemByAdminAsync_対象のアイテムが存在しない_CatalogItemNotExistingInRepositoryExceptionが発生()
+    public async Task GetCatalogItemForAdminAsync_対象のアイテムが存在しない_CatalogItemNotExistingInRepositoryExceptionが発生()
     {
         // Arrange
         var targetId = 999;
@@ -792,7 +792,7 @@ public class CatalogApplicationServiceTest(ITestOutputHelper testOutputHelper) :
         var service = new CatalogApplicationService(catalogRepositoryMock.Object, catalogBrandRepository, catalogCategoryRepository, userStoreMock.Object, catalogDomainServiceMock, logger);
 
         // Act
-        var action = () => service.GetCatalogItemByAdminAsync(targetId);
+        var action = () => service.GetCatalogItemForAdminAsync(targetId);
 
         // Assert
         await Assert.ThrowsAsync<CatalogItemNotExistingInRepositoryException>(action);


### PR DESCRIPTION
## この Pull request で実施したこと

- `GetCatalogItemForAdminAsync`と `GetCatalogItemsByAdminAsync`について、`By`を `For`に変更しました。

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

なし
