### PR TITLE
アセットコードから改行文字を取り除いてからログ出力する

### DIFF
--- a/samples/Dressca/dressca-backend/src/Dressca.ApplicationCore/ApplicationService/AssetApplicationService.cs
+++ b/samples/Dressca/dressca-backend/src/Dressca.ApplicationCore/ApplicationService/AssetApplicationService.cs
@@ -47,7 +47,7 @@ public class AssetApplicationService
     public async Task<AssetStreamInfo> GetAssetStreamInfoAsync(string assetCode)
     {
         // ログインジェクションを防ぐために改行文字を取り除きます。
-        var sanitizedAssetCode = assetCode.Replace(Environment.NewLine, string.Empty).Replace("\n", string.Empty).Replace("\r", string.Empty);
+        var sanitizedAssetCode = assetCode.RemoveNewLines();
         this.logger.LogDebug(Events.DebugEvent, LogMessages.AssetApplicationService_GetAssetStreamInfoStart, sanitizedAssetCode);
 
         Asset? asset;

--- a/samples/Dressca/dressca-backend/src/Dressca.ApplicationCore/ApplicationService/AssetApplicationService.cs
+++ b/samples/Dressca/dressca-backend/src/Dressca.ApplicationCore/ApplicationService/AssetApplicationService.cs
@@ -46,7 +46,9 @@ public class AssetApplicationService
     /// </exception>
     public async Task<AssetStreamInfo> GetAssetStreamInfoAsync(string assetCode)
     {
-        this.logger.LogDebug(Events.DebugEvent, LogMessages.AssetApplicationService_GetAssetStreamInfoStart, assetCode);
+        // ログインジェクションを防ぐために改行文字を取り除きます。
+        var sanitizedAssetCode = assetCode.Replace(Environment.NewLine, string.Empty).Replace("\n", string.Empty).Replace("\r", string.Empty);
+        this.logger.LogDebug(Events.DebugEvent, LogMessages.AssetApplicationService_GetAssetStreamInfoStart, sanitizedAssetCode);
 
         Asset? asset;
         Stream? stream;
@@ -68,7 +70,7 @@ public class AssetApplicationService
             scope.Complete();
         }
 
-        this.logger.LogDebug(Events.DebugEvent, LogMessages.AssetApplicationService_GetAssetStreamInfoEnd, assetCode);
+        this.logger.LogDebug(Events.DebugEvent, LogMessages.AssetApplicationService_GetAssetStreamInfoEnd, sanitizedAssetCode);
         return new(asset, stream);
     }
 

--- a/samples/Dressca/dressca-backend/src/Dressca.ApplicationCore/ApplicationService/AssetApplicationService.cs
+++ b/samples/Dressca/dressca-backend/src/Dressca.ApplicationCore/ApplicationService/AssetApplicationService.cs
@@ -47,7 +47,7 @@ public class AssetApplicationService
     public async Task<AssetStreamInfo> GetAssetStreamInfoAsync(string assetCode)
     {
         // ログインジェクションを防ぐために改行文字を取り除きます。
-        var sanitizedAssetCode = assetCode.RemoveNewLines();
+        var sanitizedAssetCode = assetCode.RemoveNewlineCharacters();
         this.logger.LogDebug(Events.DebugEvent, LogMessages.AssetApplicationService_GetAssetStreamInfoStart, sanitizedAssetCode);
 
         Asset? asset;

--- a/samples/Dressca/dressca-backend/src/Dressca.EfInfrastructure/Migrations/20241211091203_InitialCreate.cs
+++ b/samples/Dressca/dressca-backend/src/Dressca.EfInfrastructure/Migrations/20241211091203_InitialCreate.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Microsoft.EntityFrameworkCore.Migrations;
+﻿using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 

--- a/samples/Dressca/dressca-backend/src/Dressca.SystemCommon/StringExtentions.cs
+++ b/samples/Dressca/dressca-backend/src/Dressca.SystemCommon/StringExtentions.cs
@@ -1,0 +1,21 @@
+﻿namespace System;
+
+/// <summary>
+///  <see cref="string"/> クラスの拡張メソッドを提供します。
+/// </summary>
+public static class StringExtentions
+{
+    /// <summary>
+    ///  対象の文字列から改行文字（\r、\n）を取り除きます。
+    /// </summary>
+    /// <param name="target">対象の文字列。</param>
+    /// <returns>元の文字列から改行文字を取り除いた文字列。</returns>
+    /// <exception cref="ArgumentNullException">
+    ///  <paramref name="str"/> が <see langword="null"/> です。
+    /// </exception>
+    public static string RemoveNewLines(this string? target)
+    {
+        ArgumentNullException.ThrowIfNull(target);
+        return target.Replace("\n", string.Empty).Replace("\r", string.Empty);
+    }
+}

--- a/samples/Dressca/dressca-backend/src/Dressca.SystemCommon/StringExtentions.cs
+++ b/samples/Dressca/dressca-backend/src/Dressca.SystemCommon/StringExtentions.cs
@@ -1,4 +1,6 @@
-﻿namespace System;
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace System;
 
 /// <summary>
 ///  <see cref="string"/> クラスの拡張メソッドを提供します。
@@ -10,12 +12,14 @@ public static class StringExtentions
     /// </summary>
     /// <param name="target">対象の文字列。</param>
     /// <returns>元の文字列から改行文字を取り除いた文字列。</returns>
-    /// <exception cref="ArgumentNullException">
-    ///  <paramref name="str"/> が <see langword="null"/> です。
-    /// </exception>
-    public static string RemoveNewLines(this string? target)
+    [return: NotNullIfNotNull(nameof(target))]
+    public static string? RemoveNewLines(this string? target)
     {
-        ArgumentNullException.ThrowIfNull(target);
+        if (target == null)
+        {
+            return null;
+        }
+
         return target.Replace("\n", string.Empty).Replace("\r", string.Empty);
     }
 }

--- a/samples/Dressca/dressca-backend/src/Dressca.SystemCommon/StringExtentions.cs
+++ b/samples/Dressca/dressca-backend/src/Dressca.SystemCommon/StringExtentions.cs
@@ -13,7 +13,7 @@ public static class StringExtentions
     /// <param name="target">対象の文字列。</param>
     /// <returns>元の文字列から改行文字を取り除いた文字列。</returns>
     [return: NotNullIfNotNull(nameof(target))]
-    public static string? RemoveNewLines(this string? target)
+    public static string? RemoveNewlineCharacters(this string? target)
     {
         if (target == null)
         {

--- a/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.SystemCommon/StringExtentionsTest.cs
+++ b/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.SystemCommon/StringExtentionsTest.cs
@@ -2,6 +2,34 @@
 
 public class StringExtentionsTest
 {
+    [Theory]
+    [InlineData("\r\nLine1Line2", "Line1Line2")] // CRとLFを含む、先頭
+    [InlineData("Line1\rLine2", "Line1Line2")] // CRのみを含む、中間
+    [InlineData("Line1Line2\n", "Line1Line2")] // LFのみを含む、末尾
+    public void RemoveNewLines_改行文字があれば取り除かれる(string input, string expected)
+    {
+        // Arrange
+
+        // Act
+        var actual = input.RemoveNewLines();
+
+        // Assert
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void RemoveNewLines_改行文字なし_変化なし()
+    {
+        // Arrange
+        var target = "Line1Line2";
+
+        // Act
+        var actual = target.RemoveNewLines();
+
+        // Assert
+        Assert.Equal(target, actual);
+    }
+
     [Fact]
     public void RemoveNewLines_null_ArgumentNullExceptionが発生する()
     {
@@ -15,18 +43,44 @@ public class StringExtentionsTest
         Assert.Throws<ArgumentNullException>("target", action);
     }
 
+    [Fact]
+    public void RemoveNewLines_空文字_変化なし()
+    {
+        // Arrange
+        var target = string.Empty;
+
+        // Act
+        var actual = target.RemoveNewLines();
+
+        // Assert
+        Assert.Equal(target, actual);
+    }
+
     [Theory]
-    [InlineData("Line1\r\nLine2", "Line1Line2")] // CRとLFを含む場合
-    [InlineData("Line1\rLine2", "Line1Line2")] // CRのみを含む場合
-    [InlineData("Line1\nLine2", "Line1Line2")] // LFのみを含む場合
-    [InlineData("", "")] // 空文字の場合
-    [InlineData("Line1Line2", "Line1Line2")] // 改行文字を含まない場合
-    public void RemoveNewLines_改行文字があれば取り除かれる(string input, string expected)
+    [InlineData(" ")]
+    [InlineData("　")]
+    public void RemoveNewLines_空白文字_変化なし(string target)
     {
         // Arrange
 
         // Act
-        var actual = input.RemoveNewLines();
+        var actual = target.RemoveNewLines();
+
+        // Assert
+        Assert.Equal(target, actual);
+    }
+
+    [Theory]
+    [InlineData("\r\n")]
+    [InlineData("\r")]
+    [InlineData("\n")]
+    public void RemoveNewLines_改行コードのみ_取り除かれて空文字になる(string target)
+    {
+        // Arrange
+        var expected = string.Empty;
+
+        // Act
+        var actual = target.RemoveNewLines();
 
         // Assert
         Assert.Equal(expected, actual);

--- a/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.SystemCommon/StringExtentionsTest.cs
+++ b/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.SystemCommon/StringExtentionsTest.cs
@@ -1,0 +1,34 @@
+﻿namespace Dressca.UnitTests.SystemCommon;
+
+public class StringExtentionsTest
+{
+    [Fact]
+    public void RemoveNewLines_null_ArgumentNullExceptionが発生する()
+    {
+        // Arrange
+        string? target = null;
+
+        // Act
+        var action = () => StringExtentions.RemoveNewLines(target);
+
+        // Assert
+        Assert.Throws<ArgumentNullException>("target", action);
+    }
+
+    [Theory]
+    [InlineData("Line1\r\nLine2", "Line1Line2")] // CRとLFを含む場合
+    [InlineData("Line1\rLine2", "Line1Line2")] // CRのみを含む場合
+    [InlineData("Line1\nLine2", "Line1Line2")] // LFのみを含む場合
+    [InlineData("", "")] // 空文字の場合
+    [InlineData("Line1Line2", "Line1Line2")] // 改行文字を含まない場合
+    public void RemoveNewLines_改行文字があれば取り除かれる(string input, string expected)
+    {
+        // Arrange
+
+        // Act
+        var actual = input.RemoveNewLines();
+
+        // Assert
+        Assert.Equal(expected, actual);
+    }
+}

--- a/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.SystemCommon/StringExtentionsTest.cs
+++ b/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.SystemCommon/StringExtentionsTest.cs
@@ -31,16 +31,16 @@ public class StringExtentionsTest
     }
 
     [Fact]
-    public void RemoveNewLines_null_ArgumentNullExceptionが発生する()
+    public void RemoveNewLines_null_nullを返却()
     {
         // Arrange
         string? target = null;
 
         // Act
-        var action = () => StringExtentions.RemoveNewLines(target);
+        var actual = target.RemoveNewLines();
 
         // Assert
-        Assert.Throws<ArgumentNullException>("target", action);
+        Assert.Null(actual);
     }
 
     [Fact]

--- a/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.SystemCommon/StringExtentionsTest.cs
+++ b/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.SystemCommon/StringExtentionsTest.cs
@@ -6,51 +6,51 @@ public class StringExtentionsTest
     [InlineData("\r\nLine1Line2", "Line1Line2")] // CRとLFを含む、先頭
     [InlineData("Line1\rLine2", "Line1Line2")] // CRのみを含む、中間
     [InlineData("Line1Line2\n", "Line1Line2")] // LFのみを含む、末尾
-    public void RemoveNewLines_改行文字があれば取り除かれる(string input, string expected)
+    public void RemoveNewlineCharacters_改行文字があれば取り除かれる(string input, string expected)
     {
         // Arrange
 
         // Act
-        var actual = input.RemoveNewLines();
+        var actual = input.RemoveNewlineCharacters();
 
         // Assert
         Assert.Equal(expected, actual);
     }
 
     [Fact]
-    public void RemoveNewLines_改行文字なし_変化なし()
+    public void RemoveNewlineCharacters_改行文字なし_変化なし()
     {
         // Arrange
         var target = "Line1Line2";
 
         // Act
-        var actual = target.RemoveNewLines();
+        var actual = target.RemoveNewlineCharacters();
 
         // Assert
         Assert.Equal(target, actual);
     }
 
     [Fact]
-    public void RemoveNewLines_null_nullを返却()
+    public void RemoveNewlineCharacters_null_nullを返却()
     {
         // Arrange
         string? target = null;
 
         // Act
-        var actual = target.RemoveNewLines();
+        var actual = target.RemoveNewlineCharacters();
 
         // Assert
         Assert.Null(actual);
     }
 
     [Fact]
-    public void RemoveNewLines_空文字_変化なし()
+    public void RemoveNewlineCharacters_空文字_変化なし()
     {
         // Arrange
         var target = string.Empty;
 
         // Act
-        var actual = target.RemoveNewLines();
+        var actual = target.RemoveNewlineCharacters();
 
         // Assert
         Assert.Equal(target, actual);
@@ -59,12 +59,12 @@ public class StringExtentionsTest
     [Theory]
     [InlineData(" ")]
     [InlineData("　")]
-    public void RemoveNewLines_空白文字_変化なし(string target)
+    public void RemoveNewlineCharacters_空白文字_変化なし(string target)
     {
         // Arrange
 
         // Act
-        var actual = target.RemoveNewLines();
+        var actual = target.RemoveNewlineCharacters();
 
         // Assert
         Assert.Equal(target, actual);
@@ -74,13 +74,13 @@ public class StringExtentionsTest
     [InlineData("\r\n")]
     [InlineData("\r")]
     [InlineData("\n")]
-    public void RemoveNewLines_改行コードのみ_取り除かれて空文字になる(string target)
+    public void RemoveNewlineCharacters_改行コードのみ_取り除かれて空文字になる(string target)
     {
         // Arrange
         var expected = string.Empty;
 
         // Act
-        var actual = target.RemoveNewLines();
+        var actual = target.RemoveNewlineCharacters();
 
         // Assert
         Assert.Equal(expected, actual);


### PR DESCRIPTION
## この Pull request で実施したこと
クライアントから引き渡される文字列`assetCode`について、
改行文字を取り除いてからログに出力するよう修正しました。
そのために、`string`  クラスに改行文字を取り除く拡張メソッドを定義しました。

改行文字が含まれる場合、
攻撃者がログに任意の文字列を埋め込むことができるため、
ログを偽装されたり、ログにスクリプトを埋め込まれたりする危険性があります。

## この Pull request では実施していないこと
なし

## Issues や Discussions 、関連する Web サイトなどへのリンク
https://www.jpcert.or.jp/java-rules/ids03-j.html