### PR TITLE
remove-old-artifacts.ymlにactionsのpermissionsを追加

### DIFF
--- a/.github/workflows/remove-old-artifacts.yml
+++ b/.github/workflows/remove-old-artifacts.yml
@@ -2,6 +2,7 @@
 name: 古いアーティファクトの削除
 
 permissions:
+  actions: write
   contents: read
 
 on:


### PR DESCRIPTION
## この Pull request で実施したこと

アーティファクトの削除にはactions writeのpermissionが必要なため追加する。

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

- <https://docs.github.com/ja/rest/authentication/permissions-required-for-github-apps?apiVersion=2022-11-28#repository-permissions-for-actions>
- <https://docs.github.com/ja/rest/actions/artifacts?apiVersion=2022-11-28#delete-an-artifact>