### PR TITLE
ワークフローのサードパーティーアクションのバージョンをコミットハッシュで固定する

### DIFF
--- a/.github/workflows/build-and-release-documents.yml
+++ b/.github/workflows/build-and-release-documents.yml
@@ -83,7 +83,7 @@ jobs:
           name: documents
 
       - name: Githubのリリース
-        uses: softprops/action-gh-release@7b4da11513bf3f43f9999e90eabced41ab8bb048 #v2.2.0
+        uses: softprops/action-gh-release@7b4da11513bf3f43f9999e90eabced41ab8bb048  # v2.2.0
         with:
           files: ${{ env.DOCUMENT_ARTIFACTS_FILENAME }}
           generate_release_notes: true
@@ -101,21 +101,21 @@ jobs:
           name: documents
 
       - name: Azure に OIDC Login
-        uses: azure/login@a65d910e8af852a8061c627c456678983e180302 #v2.2.0
+        uses: azure/login@a65d910e8af852a8061c627c456678983e180302  # v2.2.0
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: ステージング環境へのデプロイ
-        uses: azure/webapps-deploy@2fdd5c3ebb4e540834e86ecc1f6fdcd5539023ee #v3.0.2
+        uses: azure/webapps-deploy@2fdd5c3ebb4e540834e86ecc1f6fdcd5539023ee  # v3.0.2
         with:
           app-name: ${{ env.APP_ALESINFINY_MARIS_WEBAPP_NAME }}
           slot-name: staging
           package: "${{ env.DOCUMENT_ARTIFACTS_FILENAME }}"
 
       - name: Teams への通知
-        uses: fjogeleit/http-request-action@23ad54bcd1178fcff6a0d17538fa09de3a7f0a4d #v1.16.4
+        uses: fjogeleit/http-request-action@23ad54bcd1178fcff6a0d17538fa09de3a7f0a4d  # v1.16.4
         with:
           url: ${{ secrets.ALESINFINY_POST_MESSAGE_TO_TEAMS_URL  }}
           method: POST
@@ -130,7 +130,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 本番環境への反映承認
-        uses: fjogeleit/http-request-action@23ad54bcd1178fcff6a0d17538fa09de3a7f0a4d #v1.16.4
+        uses: fjogeleit/http-request-action@23ad54bcd1178fcff6a0d17538fa09de3a7f0a4d  # v1.16.4
         with:
           url: ${{ secrets.ALESINFINY_APPROVE_REQUEST_TO_TEAMS_URL  }}
           method: POST

--- a/.github/workflows/build-and-release-documents.yml
+++ b/.github/workflows/build-and-release-documents.yml
@@ -83,7 +83,7 @@ jobs:
           name: documents
 
       - name: Githubのリリース
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@7b4da11513bf3f43f9999e90eabced41ab8bb048 #v2.2.0
         with:
           files: ${{ env.DOCUMENT_ARTIFACTS_FILENAME }}
           generate_release_notes: true
@@ -101,21 +101,21 @@ jobs:
           name: documents
 
       - name: Azure に OIDC Login
-        uses: azure/login@v2
+        uses: azure/login@a65d910e8af852a8061c627c456678983e180302 #v2.2.0
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: ステージング環境へのデプロイ
-        uses: azure/webapps-deploy@v3
+        uses: azure/webapps-deploy@2fdd5c3ebb4e540834e86ecc1f6fdcd5539023ee #v3.0.2
         with:
           app-name: ${{ env.APP_ALESINFINY_MARIS_WEBAPP_NAME }}
           slot-name: staging
           package: "${{ env.DOCUMENT_ARTIFACTS_FILENAME }}"
 
       - name: Teams への通知
-        uses: fjogeleit/http-request-action@v1
+        uses: fjogeleit/http-request-action@23ad54bcd1178fcff6a0d17538fa09de3a7f0a4d #v1.16.4
         with:
           url: ${{ secrets.ALESINFINY_POST_MESSAGE_TO_TEAMS_URL  }}
           method: POST
@@ -130,7 +130,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 本番環境への反映承認
-        uses: fjogeleit/http-request-action@v1
+        uses: fjogeleit/http-request-action@23ad54bcd1178fcff6a0d17538fa09de3a7f0a4d #v1.16.4
         with:
           url: ${{ secrets.ALESINFINY_APPROVE_REQUEST_TO_TEAMS_URL  }}
           method: POST

--- a/.github/workflows/build-and-release-documents.yml
+++ b/.github/workflows/build-and-release-documents.yml
@@ -108,7 +108,7 @@ jobs:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: ステージング環境へのデプロイ
-        uses: azure/webapps-deploy@2fdd5c3ebb4e540834e86ecc1f6fdcd5539023ee  # v3.0.2
+        uses: azure/webapps-deploy@de617f46172a906d0617bb0e50d81e9e3aec24c8  # v3.0.1
         with:
           app-name: ${{ env.APP_ALESINFINY_MARIS_WEBAPP_NAME }}
           slot-name: staging

--- a/.github/workflows/check-openapi-generator-update.yml
+++ b/.github/workflows/check-openapi-generator-update.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: GitHub API経由でリポジトリの情報を取得
         id: get-repo-info-via-github-api
-        uses: fjogeleit/http-request-action@v1
+        uses: fjogeleit/http-request-action@23ad54bcd1178fcff6a0d17538fa09de3a7f0a4d #v1.16.4 
         with:
           url: 'https://api.github.com/repos/OpenAPITools/openapi-generator/releases/latest'
           method: 'GET'
@@ -70,7 +70,7 @@ jobs:
       - name: issue を作成（Dressca-Consumer）
         id: create-issue-consumer
         if: ${{ steps.check-version-update.outputs.update-required-consumer == 'true' }}
-        uses: Wandalen/wretry.action@master
+        uses: Wandalen/wretry.action@ffdd254f4eaf1562b8a2c66aeaa37f1ff2231179 #v3.7.3
         with:
           action: dblock/create-a-github-issue@v3
           with: |
@@ -108,7 +108,7 @@ jobs:
       - name: issue を作成（Dressca-Admin）
         id: create-issue-admin
         if: ${{ steps.check-version-update.outputs.update-required-admin == 'true' }}
-        uses: Wandalen/wretry.action@master
+        uses: Wandalen/wretry.action@ffdd254f4eaf1562b8a2c66aeaa37f1ff2231179 #v3.7.3
         with:
           action: dblock/create-a-github-issue@v3
           with: |

--- a/.github/workflows/check-openapi-generator-update.yml
+++ b/.github/workflows/check-openapi-generator-update.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: GitHub API経由でリポジトリの情報を取得
         id: get-repo-info-via-github-api
-        uses: fjogeleit/http-request-action@23ad54bcd1178fcff6a0d17538fa09de3a7f0a4d  # v1.16.4 
+        uses: fjogeleit/http-request-action@23ad54bcd1178fcff6a0d17538fa09de3a7f0a4d  # v1.16.4
         with:
           url: 'https://api.github.com/repos/OpenAPITools/openapi-generator/releases/latest'
           method: 'GET'

--- a/.github/workflows/check-openapi-generator-update.yml
+++ b/.github/workflows/check-openapi-generator-update.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: GitHub API経由でリポジトリの情報を取得
         id: get-repo-info-via-github-api
-        uses: fjogeleit/http-request-action@23ad54bcd1178fcff6a0d17538fa09de3a7f0a4d #v1.16.4 
+        uses: fjogeleit/http-request-action@23ad54bcd1178fcff6a0d17538fa09de3a7f0a4d  # v1.16.4 
         with:
           url: 'https://api.github.com/repos/OpenAPITools/openapi-generator/releases/latest'
           method: 'GET'
@@ -70,7 +70,7 @@ jobs:
       - name: issue を作成（Dressca-Consumer）
         id: create-issue-consumer
         if: ${{ steps.check-version-update.outputs.update-required-consumer == 'true' }}
-        uses: Wandalen/wretry.action@ffdd254f4eaf1562b8a2c66aeaa37f1ff2231179 #v3.7.3
+        uses: Wandalen/wretry.action@ffdd254f4eaf1562b8a2c66aeaa37f1ff2231179  # v3.7.3
         with:
           action: dblock/create-a-github-issue@v3
           with: |
@@ -108,7 +108,7 @@ jobs:
       - name: issue を作成（Dressca-Admin）
         id: create-issue-admin
         if: ${{ steps.check-version-update.outputs.update-required-admin == 'true' }}
-        uses: Wandalen/wretry.action@ffdd254f4eaf1562b8a2c66aeaa37f1ff2231179 #v3.7.3
+        uses: Wandalen/wretry.action@ffdd254f4eaf1562b8a2c66aeaa37f1ff2231179  # v3.7.3
         with:
           action: dblock/create-a-github-issue@v3
           with: |

--- a/.github/workflows/remove-old-artifacts.yml
+++ b/.github/workflows/remove-old-artifacts.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: 古いアーティファクトの削除
-        uses: c-hive/gha-remove-artifacts@v1
+        uses: c-hive/gha-remove-artifacts@44fc7acaf1b3d0987da0e8d4707a989d80e9554b #v1.4.0
         with:
           age: '{{ github.event.inputs.target }} days'
           skip-tags: true

--- a/.github/workflows/remove-old-artifacts.yml
+++ b/.github/workflows/remove-old-artifacts.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: 古いアーティファクトの削除
-        uses: c-hive/gha-remove-artifacts@44fc7acaf1b3d0987da0e8d4707a989d80e9554b #v1.4.0
+        uses: c-hive/gha-remove-artifacts@44fc7acaf1b3d0987da0e8d4707a989d80e9554b  # v1.4.0
         with:
           age: '{{ github.event.inputs.target }} days'
           skip-tags: true

--- a/.github/workflows/samples-azure-ad-b2c-auth-ci.yml
+++ b/.github/workflows/samples-azure-ad-b2c-auth-ci.yml
@@ -145,7 +145,7 @@ jobs:
 
       - id: create-test-result-report
         name: テスト結果ページの作成
-        uses: dorny/test-reporter@31a54ee7ebcacc03a09ea97a7e5465a47b84aea5 #v1.9.1
+        uses: dorny/test-reporter@31a54ee7ebcacc03a09ea97a7e5465a47b84aea5  # v1.9.1
         if: ${{ success() || (failure() && steps.run-tests.conclusion == 'failure') }}
         with:
           name: 'バックエンドのテスト結果'
@@ -169,7 +169,7 @@ jobs:
 
       - id: create-coverage-report
         name: コードカバレッジレポートの解析と作成
-        uses: danielpalme/ReportGenerator-GitHub-Action@c38c522d4b391c1b0da979cbb2e902c0a252a7dc #v5.4.3
+        uses: danielpalme/ReportGenerator-GitHub-Action@c38c522d4b391c1b0da979cbb2e902c0a252a7dc  # v5.4.3
         if: ${{ success() || (failure() && steps.run-tests.conclusion == 'failure') }}
         with:
           reports: '**/TestResults/*/coverage.cobertura.xml'

--- a/.github/workflows/samples-azure-ad-b2c-auth-ci.yml
+++ b/.github/workflows/samples-azure-ad-b2c-auth-ci.yml
@@ -145,7 +145,7 @@ jobs:
 
       - id: create-test-result-report
         name: テスト結果ページの作成
-        uses: dorny/test-reporter@v1
+        uses: dorny/test-reporter@31a54ee7ebcacc03a09ea97a7e5465a47b84aea5 #v1.9.1
         if: ${{ success() || (failure() && steps.run-tests.conclusion == 'failure') }}
         with:
           name: 'バックエンドのテスト結果'
@@ -169,7 +169,7 @@ jobs:
 
       - id: create-coverage-report
         name: コードカバレッジレポートの解析と作成
-        uses: danielpalme/ReportGenerator-GitHub-Action@v5
+        uses: danielpalme/ReportGenerator-GitHub-Action@c38c522d4b391c1b0da979cbb2e902c0a252a7dc #v5.4.3
         if: ${{ success() || (failure() && steps.run-tests.conclusion == 'failure') }}
         with:
           reports: '**/TestResults/*/coverage.cobertura.xml'

--- a/.github/workflows/samples-console-app-with-di.ci.yml
+++ b/.github/workflows/samples-console-app-with-di.ci.yml
@@ -61,7 +61,7 @@ jobs:
 
       - id: create-test-result-report
         name: テスト結果ページの作成
-        uses: dorny/test-reporter@v1
+        uses: dorny/test-reporter@31a54ee7ebcacc03a09ea97a7e5465a47b84aea5 #v1.9.1
         if: ${{ success() || (failure() && steps.run-tests.conclusion == 'failure') }}
         with:
           name: 'Test results'
@@ -85,7 +85,7 @@ jobs:
 
       - id: create-coverage-report
         name: コードカバレッジレポートの解析と作成
-        uses: danielpalme/ReportGenerator-GitHub-Action@v5
+        uses: danielpalme/ReportGenerator-GitHub-Action@c38c522d4b391c1b0da979cbb2e902c0a252a7dc #v5.4.3
         if: ${{ success() || (failure() && steps.run-tests.conclusion == 'failure') }}
         with:
           reports: '**/TestResults/*/coverage.cobertura.xml'
@@ -102,7 +102,7 @@ jobs:
           cat CoverageReport/SummaryGithub.md >> ${{ env.BUILD_SUMMARY_FILE }}
 
       - name: ビルドサマリーをPull-requestに表示
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 #v2.9.0
         if: ${{ github.event_name == 'pull_request' && (success() || (failure() && steps.run-tests.conclusion == 'failure')) }}
         with:
           recreate: true

--- a/.github/workflows/samples-console-app-with-di.ci.yml
+++ b/.github/workflows/samples-console-app-with-di.ci.yml
@@ -61,7 +61,7 @@ jobs:
 
       - id: create-test-result-report
         name: テスト結果ページの作成
-        uses: dorny/test-reporter@31a54ee7ebcacc03a09ea97a7e5465a47b84aea5 #v1.9.1
+        uses: dorny/test-reporter@31a54ee7ebcacc03a09ea97a7e5465a47b84aea5  # v1.9.1
         if: ${{ success() || (failure() && steps.run-tests.conclusion == 'failure') }}
         with:
           name: 'Test results'
@@ -85,7 +85,7 @@ jobs:
 
       - id: create-coverage-report
         name: コードカバレッジレポートの解析と作成
-        uses: danielpalme/ReportGenerator-GitHub-Action@c38c522d4b391c1b0da979cbb2e902c0a252a7dc #v5.4.3
+        uses: danielpalme/ReportGenerator-GitHub-Action@c38c522d4b391c1b0da979cbb2e902c0a252a7dc  # v5.4.3
         if: ${{ success() || (failure() && steps.run-tests.conclusion == 'failure') }}
         with:
           reports: '**/TestResults/*/coverage.cobertura.xml'
@@ -102,7 +102,7 @@ jobs:
           cat CoverageReport/SummaryGithub.md >> ${{ env.BUILD_SUMMARY_FILE }}
 
       - name: ビルドサマリーをPull-requestに表示
-        uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 #v2.9.0
+        uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31  # v2.9.0
         if: ${{ github.event_name == 'pull_request' && (success() || (failure() && steps.run-tests.conclusion == 'failure')) }}
         with:
           recreate: true

--- a/.github/workflows/samples-dressca-admin-backend.ci.yml
+++ b/.github/workflows/samples-dressca-admin-backend.ci.yml
@@ -96,7 +96,7 @@ jobs:
 
       - id: create-test-result-report
         name: テスト結果ページの作成
-        uses: dorny/test-reporter@v1
+        uses: dorny/test-reporter@31a54ee7ebcacc03a09ea97a7e5465a47b84aea5 #v1.9.1
         if: ${{ success() || (failure() && steps.run-tests.conclusion == 'failure') }}
         with:
           name: 'Test results'
@@ -120,7 +120,7 @@ jobs:
 
       - id: create-coverage-report
         name: コードカバレッジレポートの解析と作成
-        uses: danielpalme/ReportGenerator-GitHub-Action@v5
+        uses: danielpalme/ReportGenerator-GitHub-Action@c38c522d4b391c1b0da979cbb2e902c0a252a7dc #v5.4.3
         if: ${{ success() || (failure() && steps.run-tests.conclusion == 'failure') }}
         with:
           reports: '**/TestResults/*/coverage.cobertura.xml'
@@ -137,7 +137,7 @@ jobs:
           cat CoverageReport/SummaryGithub.md >> ${{ env.BUILD_SUMMARY_FILE }}
 
       - name: ビルドサマリーをPull-requestに表示
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 #v2.9.0
         if: ${{ github.event_name == 'pull_request' && (success() || (failure() && steps.run-tests.conclusion == 'failure')) }}
         with:
           recreate: true

--- a/.github/workflows/samples-dressca-admin-backend.ci.yml
+++ b/.github/workflows/samples-dressca-admin-backend.ci.yml
@@ -96,7 +96,7 @@ jobs:
 
       - id: create-test-result-report
         name: テスト結果ページの作成
-        uses: dorny/test-reporter@31a54ee7ebcacc03a09ea97a7e5465a47b84aea5 #v1.9.1
+        uses: dorny/test-reporter@31a54ee7ebcacc03a09ea97a7e5465a47b84aea5  # v1.9.1
         if: ${{ success() || (failure() && steps.run-tests.conclusion == 'failure') }}
         with:
           name: 'Test results'
@@ -120,7 +120,7 @@ jobs:
 
       - id: create-coverage-report
         name: コードカバレッジレポートの解析と作成
-        uses: danielpalme/ReportGenerator-GitHub-Action@c38c522d4b391c1b0da979cbb2e902c0a252a7dc #v5.4.3
+        uses: danielpalme/ReportGenerator-GitHub-Action@c38c522d4b391c1b0da979cbb2e902c0a252a7dc  # v5.4.3
         if: ${{ success() || (failure() && steps.run-tests.conclusion == 'failure') }}
         with:
           reports: '**/TestResults/*/coverage.cobertura.xml'
@@ -137,7 +137,7 @@ jobs:
           cat CoverageReport/SummaryGithub.md >> ${{ env.BUILD_SUMMARY_FILE }}
 
       - name: ビルドサマリーをPull-requestに表示
-        uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 #v2.9.0
+        uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31  # v2.9.0
         if: ${{ github.event_name == 'pull_request' && (success() || (failure() && steps.run-tests.conclusion == 'failure')) }}
         with:
           recreate: true

--- a/.github/workflows/samples-dressca-consumer-backend.ci.yml
+++ b/.github/workflows/samples-dressca-consumer-backend.ci.yml
@@ -96,7 +96,7 @@ jobs:
 
       - id: create-test-result-report
         name: テスト結果ページの作成
-        uses: dorny/test-reporter@v1
+        uses: dorny/test-reporter@31a54ee7ebcacc03a09ea97a7e5465a47b84aea5 #v1.9.1
         if: ${{ success() || (failure() && steps.run-tests.conclusion == 'failure') }}
         with:
           name: 'Test results'
@@ -120,7 +120,7 @@ jobs:
 
       - id: create-coverage-report
         name: コードカバレッジレポートの解析と作成
-        uses: danielpalme/ReportGenerator-GitHub-Action@v5
+        uses: danielpalme/ReportGenerator-GitHub-Action@c38c522d4b391c1b0da979cbb2e902c0a252a7dc #v5.4.3
         if: ${{ success() || (failure() && steps.run-tests.conclusion == 'failure') }}
         with:
           reports: '**/TestResults/*/coverage.cobertura.xml'
@@ -137,7 +137,7 @@ jobs:
           cat CoverageReport/SummaryGithub.md >> ${{ env.BUILD_SUMMARY_FILE }}
 
       - name: ビルドサマリーをPull-requestに表示
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 #v2.9.0
         if: ${{ github.event_name == 'pull_request' && (success() || (failure() && steps.run-tests.conclusion == 'failure')) }}
         with:
           recreate: true

--- a/.github/workflows/samples-dressca-consumer-backend.ci.yml
+++ b/.github/workflows/samples-dressca-consumer-backend.ci.yml
@@ -96,7 +96,7 @@ jobs:
 
       - id: create-test-result-report
         name: テスト結果ページの作成
-        uses: dorny/test-reporter@31a54ee7ebcacc03a09ea97a7e5465a47b84aea5 #v1.9.1
+        uses: dorny/test-reporter@31a54ee7ebcacc03a09ea97a7e5465a47b84aea5  # v1.9.1
         if: ${{ success() || (failure() && steps.run-tests.conclusion == 'failure') }}
         with:
           name: 'Test results'
@@ -120,7 +120,7 @@ jobs:
 
       - id: create-coverage-report
         name: コードカバレッジレポートの解析と作成
-        uses: danielpalme/ReportGenerator-GitHub-Action@c38c522d4b391c1b0da979cbb2e902c0a252a7dc #v5.4.3
+        uses: danielpalme/ReportGenerator-GitHub-Action@c38c522d4b391c1b0da979cbb2e902c0a252a7dc  # v5.4.3
         if: ${{ success() || (failure() && steps.run-tests.conclusion == 'failure') }}
         with:
           reports: '**/TestResults/*/coverage.cobertura.xml'
@@ -137,7 +137,7 @@ jobs:
           cat CoverageReport/SummaryGithub.md >> ${{ env.BUILD_SUMMARY_FILE }}
 
       - name: ビルドサマリーをPull-requestに表示
-        uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 #v2.9.0
+        uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31  # v2.9.0
         if: ${{ github.event_name == 'pull_request' && (success() || (failure() && steps.run-tests.conclusion == 'failure')) }}
         with:
           recreate: true


### PR DESCRIPTION
## この Pull request で実施したこと

ワークフローで利用しているサードパーティーのアクションをコミットハッシュを使って指定するように修正しました。
コミットハッシュでアクションのバージョンを固定することで、サプライチェーン攻撃によって意図しないアクションが実行されることを防ぎます。

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions
