### PR TITLE
softprops/action-gh-releaseのバージョンを v2.2.1 に更新

### DIFF
--- a/.github/workflows/build-and-release-documents.yml
+++ b/.github/workflows/build-and-release-documents.yml
@@ -83,7 +83,7 @@ jobs:
           name: documents
 
       - name: Githubのリリース
-        uses: softprops/action-gh-release@7b4da11513bf3f43f9999e90eabced41ab8bb048  # v2.2.0
+        uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda  # v2.2.1
         with:
           files: ${{ env.DOCUMENT_ARTIFACTS_FILENAME }}
           generate_release_notes: true


### PR DESCRIPTION
## この Pull request で実施したこと

softprops/action-gh-releaseのバージョンを `v2.2.1` に修正しました。

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

なし
