### PR TITLE
AdminのControllerのAuthorizeに渡す値が誤っている問題を修正

### DIFF
--- a/samples/Dressca/dressca-backend/src/Dressca.ApplicationCore/Authorization/Roles.cs
+++ b/samples/Dressca/dressca-backend/src/Dressca.ApplicationCore/Authorization/Roles.cs
@@ -8,5 +8,5 @@ public static class Roles
     /// <summary>
     ///  管理者のロールを表す文字列です。
     /// </summary>
-    public static readonly string Admin = "Admin";
+    public static readonly string Admin = "ROLE_ADMIN";
 }

--- a/samples/Dressca/dressca-backend/src/Dressca.Web.Admin/Authorization/Policies.cs
+++ b/samples/Dressca/dressca-backend/src/Dressca.Web.Admin/Authorization/Policies.cs
@@ -1,0 +1,12 @@
+﻿namespace Dressca.Web.Admin.Authorization;
+
+/// <summary>
+///  ポリシーを管理するための静的クラスです。
+/// </summary>
+internal static class Policies
+{
+    /// <summary>
+    ///  管理者ロールが必要であるというポリシーを示す文字列です。
+    /// </summary>
+    internal const string RequireAdminRole = "RequireAdminRole";
+}

--- a/samples/Dressca/dressca-backend/src/Dressca.Web.Admin/Controllers/CatalogItemsController.cs
+++ b/samples/Dressca/dressca-backend/src/Dressca.Web.Admin/Controllers/CatalogItemsController.cs
@@ -3,6 +3,7 @@ using Dressca.ApplicationCore.Authorization;
 using Dressca.ApplicationCore.Catalog;
 using Dressca.SystemCommon;
 using Dressca.SystemCommon.Mapper;
+using Dressca.Web.Admin.Authorization;
 using Dressca.Web.Admin.Controllers.ApiModel;
 using Dressca.Web.Admin.Dto.CatalogItems;
 using Dressca.Web.Controllers;
@@ -65,7 +66,7 @@ public class CatalogItemsController : ControllerBase
     [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ProblemDetails))]
     [ProducesResponseType(StatusCodes.Status500InternalServerError, Type = typeof(ProblemDetails))]
     [OpenApiOperation("getCatalogItem")]
-    [Authorize(Roles = nameof(Admin))]
+    [Authorize(Policy = Policies.RequireAdminRole)]
     public async Task<IActionResult> GetCatalogItemAsync(long catalogItemId)
     {
         CatalogItem? catalogItem;
@@ -106,7 +107,7 @@ public class CatalogItemsController : ControllerBase
     [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ProblemDetails))]
     [ProducesResponseType(StatusCodes.Status500InternalServerError, Type = typeof(ProblemDetails))]
     [OpenApiOperation("getByQuery")]
-    [Authorize(Roles = nameof(Admin))]
+    [Authorize(Policy = Policies.RequireAdminRole)]
     public async Task<IActionResult> GetByQueryAsync([FromQuery] FindCatalogItemsQuery query)
     {
         (IReadOnlyList<CatalogItem> CatalogItems, int TotalCount) itemsAndCount;
@@ -154,7 +155,7 @@ public class CatalogItemsController : ControllerBase
     [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ProblemDetails))]
     [ProducesResponseType(StatusCodes.Status500InternalServerError, Type = typeof(ProblemDetails))]
     [OpenApiOperation("postCatalogItem")]
-    [Authorize(Roles = nameof(Admin))]
+    [Authorize(Policy = Policies.RequireAdminRole)]
     public async Task<IActionResult> PostCatalogItemAsync(PostCatalogItemRequest postCatalogItemRequest)
     {
         CatalogItem catalogItem;
@@ -200,7 +201,7 @@ public class CatalogItemsController : ControllerBase
     [ProducesResponseType(StatusCodes.Status409Conflict, Type = typeof(ProblemDetails))]
     [ProducesResponseType(StatusCodes.Status500InternalServerError, Type = typeof(ProblemDetails))]
     [OpenApiOperation("deleteCatalogItem")]
-    [Authorize(Roles = nameof(Admin))]
+    [Authorize(Policy = Policies.RequireAdminRole)]
     public async Task<IActionResult> DeleteCatalogItemAsync(long catalogItemId, [FromQuery] byte[] rowVersion)
     {
         try
@@ -241,7 +242,7 @@ public class CatalogItemsController : ControllerBase
     [ProducesResponseType(StatusCodes.Status409Conflict, Type = typeof(ProblemDetails))]
     [ProducesResponseType(StatusCodes.Status500InternalServerError, Type = typeof(ProblemDetails))]
     [OpenApiOperation("putCatalogItem")]
-    [Authorize(Roles = nameof(Admin))]
+    [Authorize(Policy = Policies.RequireAdminRole)]
     public async Task<IActionResult> PutCatalogItemAsync(long catalogItemId, PutCatalogItemRequest putCatalogItemRequest)
     {
         try

--- a/samples/Dressca/dressca-backend/src/Dressca.Web.Admin/Program.cs
+++ b/samples/Dressca/dressca-backend/src/Dressca.Web.Admin/Program.cs
@@ -90,7 +90,6 @@ if (builder.Environment.IsDevelopment())
     // ローカル開発環境用の認証ハンドラーを登録します。
     _ = builder.Services.AddAuthentication("DummyAuthentication")
     .AddScheme<AuthenticationSchemeOptions, DummyAuthenticationHandler>("DummyAuthentication", null);
-    builder.Services.AddAuthorization();
 
     builder.Services.AddHttpLogging(logging =>
     {
@@ -103,6 +102,9 @@ else if (builder.Environment.IsProduction())
 {
     // 本番環境用の認証ハンドラーを登録します。
 }
+
+builder.Services.AddAuthorizationBuilder()
+    .AddPolicy(Policies.RequireAdminRole, policy => policy.RequireRole(Roles.Admin));
 
 builder.Services.AddSingleton<
     IAuthorizationMiddlewareResultHandler, StatusCodeMapAuthorizationMiddlewareResultHandler>();

--- a/samples/Dressca/dressca-backend/src/Dressca.Web.Admin/dressca-admin-api.json
+++ b/samples/Dressca/dressca-backend/src/Dressca.Web.Admin/dressca-admin-api.json
@@ -871,7 +871,7 @@
           },
           "price": {
             "type": "integer",
-            "description": "単価を取得または設定します。",
+            "description": "単価を取得または設定します。\n            ",
             "format": "int64",
             "pattern": "^[1-9]\\d{0,15}$"
           },

--- a/samples/Dressca/dressca-backend/src/Dressca.Web/Authorization/DummyAuthenticationHandler.cs
+++ b/samples/Dressca/dressca-backend/src/Dressca.Web/Authorization/DummyAuthenticationHandler.cs
@@ -28,7 +28,7 @@ public class DummyAuthenticationHandler : AuthenticationHandler<AuthenticationSc
         // ダミーのユーザー名とロール名を設定します。
         Claim[] claims = [
             new Claim(ClaimTypes.Name, "dummy_user"),
-            new Claim(ClaimTypes.Role, "Admin")
+            new Claim(ClaimTypes.Role, "ROLE_ADMIN")
         ];
         var identity = new ClaimsIdentity(claims, this.Scheme.Name);
         var principal = new ClaimsPrincipal(identity);


### PR DESCRIPTION
## この Pull request で実施したこと
- 属性式にはreadonlyの値を渡せない（`[Authorize(Roles = Roles.Admin]`）ので、
- フロントエンド側の下記の変更に備えて、管理者ロールを表す定数の文字列をmaia側に揃えて`ROLE_ADMIN`に変更しました。
    - https://github.com/AlesInfiny/maia/pull/1798
## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

なし
