### PR TITLE
Dresscaの依存するNuGetパッケージを更新（8.0.11 > 8.0.12）

### DIFF
--- a/samples/Dressca/dressca-backend/Directory.Packages.props
+++ b/samples/Dressca/dressca-backend/Directory.Packages.props
@@ -1,14 +1,14 @@
 <Project>
   <ItemGroup>
     <PackageVersion Include="coverlet.collector" Version="6.0.3" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.11" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.11" />
-    <PackageVersion Include="Microsoft.AspNetCore.SpaProxy" Version="8.0.11" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="8.0.11" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.11" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.11" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.12" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.12" />
+    <PackageVersion Include="Microsoft.AspNetCore.SpaProxy" Version="8.0.12" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="8.0.12" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.12" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.12" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.12" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.Testing" Version="8.10.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />


### PR DESCRIPTION
## この Pull request で実施したこと

`Microsoft.AspNetCore.Mvc.Testing`、`Microsoft.AspNetCore.Mvc.NewtonsoftJson`、`Microsoft.AspNetCore.SpaProxy`、`Microsoft.EntityFrameworkCore`、`Microsoft.EntityFrameworkCore.Design`、`Microsoft.EntityFrameworkCore.SqlServer`、および `Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore` のバージョンを `8.0.11` から `8.0.12` に更新しました。

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

以下のdependabotのPRは、9.0をターゲットとするものが含まれるため利用しません。

- https://github.com/AlesInfiny/maris/pull/2271
