### PR TITLE
AzureADB2Cサンプルとconsumerのpreview時のポートを未指定（デフォルト値）に統一

### DIFF
--- a/samples/AzureADB2CAuth/auth-frontend/app/package.json
+++ b/samples/AzureADB2CAuth/auth-frontend/app/package.json
@@ -8,7 +8,7 @@
     "build:dev": "run-p type-check build-only:dev --print-label",
     "build-only:prod": "vite build --mode prod",
     "build-only:dev": "vite build --mode dev",
-    "preview": "vite preview --port 5050",
+    "preview": "vite preview",
     "test:unit": "vitest",
     "type-check": "vue-tsc --build --force",
     "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --fix --ignore-path .gitignore",

--- a/samples/Dressca/dressca-frontend/consumer/package.json
+++ b/samples/Dressca/dressca-frontend/consumer/package.json
@@ -8,7 +8,7 @@
     "build:dev": "run-p type-check build-only:dev --print-label",
     "build-only:prod": "vite build --mode prod",
     "build-only:dev": "vite build --mode dev",
-    "preview": "vite preview --port 5173",
+    "preview": "vite preview",
     "test:unit": "vitest",
     "test:e2e": "start-server-and-test dev http://localhost:5173/ 'cypress open --e2e --browser chrome'",
     "test:e2e:ci": "start-server-and-test dev http://localhost:5173/ 'cypress run'",


### PR DESCRIPTION
## この Pull request で実施したこと

- AzureADB2CサンプルとDressacaのconsumerについて、`vite preview`実行時のポートを未指定（デフォルト値）に統一しました。
- 修正対象のワークスペースで`npm run preview`を行い、Viteのサーバーが問題なく立ち上がることを確認しました。

## この Pull request では実施していないこと

admin はcreate-vueを行ったタイミングの関係で既に未指定になっていたため、対応していません。

## Issues や Discussions 、関連する Web サイトなどへのリンク
maia 側は下記の通り v1.01 にて対応します。
- https://github.com/AlesInfiny/maia/pull/1858