### PR TITLE
注意書きのテキストボックスの表示崩れを修正

### DIFF
--- a/documents/contents/guidebooks/how-to-develop/dotnet/create-solution-structure.md
+++ b/documents/contents/guidebooks/how-to-develop/dotnet/create-solution-structure.md
@@ -68,14 +68,14 @@ src フォルダーにはプロダクションコードを、 tests フォルダ
     プロダクションコードとテストコードでは、通常コーディングルールの厳しさに濃淡をつけます[^1]。
     そのため、プロダクションコードを配置するフォルダーとテストコードを配置するフォルダーを最初に分類しておくことで、各コード向けの .editorconfig ファイルの適用が簡単になります。
 
-<!-- textlint-enable ja-technical-writing/sentence-length -->
-
     またフォルダー構造に基づく設定は、他にもいくつか存在します。
 
     - [Directory.Build.props と Directory.Build.targets :material-open-in-new:](https://learn.microsoft.com/ja-jp/visualstudio/msbuild/customize-your-build#directorybuildprops-and-directorybuildtargets){ target=_blank }
     - [Central Package Management :material-open-in-new:](https://devblogs.microsoft.com/nuget/introducing-central-package-management/){ target=_blank }
 
     プロダクションコードを配置するフォルダーとテストコードを配置するフォルダーの分割は、これらの機能を活用するためにも役立ちます。
+
+<!-- textlint-enable ja-technical-writing/sentence-length -->
 
 ## プロジェクト配置の定義 {#define-project}
 


### PR DESCRIPTION
## この Pull request で実施したこと

- 注意書きの途中にtextlint-enableの設定を記載すると表示が崩れてしまうため、
設定の記載位置を修正いたしました。

## この Pull request では実施していないこと
なし

## Issues や Discussions 、関連する Web サイトなどへのリンク
- 表示崩れの例を示します。
![image](https://github.com/user-attachments/assets/770bba01-1b76-4b19-ba75-981244d84b5a)

