### PR TITLE
issueの作成処理の終了ステータスが不正な場合にワークフローを異常終了させる

### DIFF
--- a/.github/workflows/check-openapi-generator-update.yml
+++ b/.github/workflows/check-openapi-generator-update.yml
@@ -108,6 +108,7 @@ jobs:
             echo "同名の issue が存在するため、更新のみ行いました。" >> $GITHUB_STEP_SUMMARY
           else
             echo "ステータスの値が不正です。" >> $GITHUB_STEP_SUMMARY
+            exit 1
           fi
           echo issue number: $ISSUE_NUMBER >> $GITHUB_STEP_SUMMARY
           echo status: $STATUS >> $GITHUB_STEP_SUMMARY
@@ -145,6 +146,7 @@ jobs:
             echo "同名の issue が存在するため、更新のみ行いました。" >> $GITHUB_STEP_SUMMARY
           else
             echo "ステータスの値が不正です。" >> $GITHUB_STEP_SUMMARY
+            exit 1
           fi
           echo issue number: $ISSUE_NUMBER >> $GITHUB_STEP_SUMMARY
           echo status: $STATUS >> $GITHUB_STEP_SUMMARY
@@ -182,6 +184,7 @@ jobs:
             echo "同名の issue が存在するため、更新のみ行いました。" >> $GITHUB_STEP_SUMMARY
           else
             echo "ステータスの値が不正です。" >> $GITHUB_STEP_SUMMARY
+            exit 1
           fi
           echo issue number: $ISSUE_NUMBER >> $GITHUB_STEP_SUMMARY
           echo status: $STATUS >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## この Pull request で実施したこと

- issue作成処理の終了ステータスの値が不正な場合は異常終了させるように修正しました。

## この Pull request では実施していないこと

- 対象のカスタムアクションの終了ステータスの不正を人為的に発生させることが難しいので、実際の挙動は確認できていませんが、この分岐に入った場合は異常終了して欲しいため、リスクは極めて低く問題ないと考えます。

## Issues や Discussions 、関連する Web サイトなどへのリンク

なし
