### PR TITLE
Dresscaをxunit v3に更新する

### DIFF
--- a/.github/workflows/samples-dressca-admin-backend.ci.yml
+++ b/.github/workflows/samples-dressca-admin-backend.ci.yml
@@ -92,7 +92,7 @@ jobs:
         continue-on-error: true
         run: |
           export TEST_ENVIRONMENT=${{ env.TEST_ENVIRONMENT }}
-                    dotnet test ${{ env.SOLUTION_FILE_NAME }} --no-build --verbosity normal --configuration ${{ env.BUILD_CONFIGURATION }} -- --coverage --coverage-output-format cobertura --coverage-output coverage.cobertura.xml --report-xunit-trx
+          dotnet test ${{ env.SOLUTION_FILE_NAME }} --no-build --verbosity normal --configuration ${{ env.BUILD_CONFIGURATION }} -- --coverage --coverage-output-format cobertura --coverage-output coverage.cobertura.xml --report-xunit-trx
 
       - id: create-test-result-report
         name: テスト結果ページの作成

--- a/.github/workflows/samples-dressca-admin-backend.ci.yml
+++ b/.github/workflows/samples-dressca-admin-backend.ci.yml
@@ -123,7 +123,7 @@ jobs:
         uses: danielpalme/ReportGenerator-GitHub-Action@f1927db1dbfc029b056583ee488832e939447fe6  # v5.4.4
         if: ${{ success() || (failure() && steps.run-tests.conclusion == 'failure') }}
         with:
-          reports: '**/TestResults/*/coverage.cobertura.xml'
+          reports: '**/TestResults/coverage.cobertura.xml'
           targetdir: '${{ env.WORKING_DIRECTORY }}/CoverageReport'
           reporttypes: 'MarkdownSummaryGithub'
 

--- a/.github/workflows/samples-dressca-admin-backend.ci.yml
+++ b/.github/workflows/samples-dressca-admin-backend.ci.yml
@@ -92,7 +92,7 @@ jobs:
         continue-on-error: true
         run: |
           export TEST_ENVIRONMENT=${{ env.TEST_ENVIRONMENT }}
-          dotnet test ${{ env.SOLUTION_FILE_NAME }} --no-build --logger trx --verbosity normal --configuration ${{ env.BUILD_CONFIGURATION }}  --collect "XPlat Code Coverage"
+                    dotnet test ${{ env.SOLUTION_FILE_NAME }} --no-build --verbosity normal --configuration ${{ env.BUILD_CONFIGURATION }} -- --coverage --coverage-output-format cobertura --coverage-output coverage.cobertura.xml --report-xunit-trx
 
       - id: create-test-result-report
         name: テスト結果ページの作成

--- a/.github/workflows/samples-dressca-consumer-backend.ci.yml
+++ b/.github/workflows/samples-dressca-consumer-backend.ci.yml
@@ -123,7 +123,7 @@ jobs:
         uses: danielpalme/ReportGenerator-GitHub-Action@f1927db1dbfc029b056583ee488832e939447fe6  # v5.4.4
         if: ${{ success() || (failure() && steps.run-tests.conclusion == 'failure') }}
         with:
-          reports: '**/TestResults/*/coverage.cobertura.xml'
+          reports: '**/TestResults/coverage.cobertura.xml'
           targetdir: '${{ env.WORKING_DIRECTORY }}/CoverageReport'
           reporttypes: 'MarkdownSummaryGithub'
 

--- a/.github/workflows/samples-dressca-consumer-backend.ci.yml
+++ b/.github/workflows/samples-dressca-consumer-backend.ci.yml
@@ -92,7 +92,7 @@ jobs:
         continue-on-error: true
         run: |
           export TEST_ENVIRONMENT=${{ env.TEST_ENVIRONMENT }}
-          dotnet test ${{ env.SOLUTION_FILE_NAME }} --no-build --logger trx --verbosity normal --configuration ${{ env.BUILD_CONFIGURATION }}  --collect "XPlat Code Coverage"
+          dotnet test ${{ env.SOLUTION_FILE_NAME }} --no-build --verbosity normal --configuration ${{ env.BUILD_CONFIGURATION }} -- --coverage --coverage-output-format cobertura --coverage-output coverage.cobertura.xml --report-xunit-trx
 
       - id: create-test-result-report
         name: テスト結果ページの作成

--- a/samples/Dressca/dressca-backend/Directory.Packages.props
+++ b/samples/Dressca/dressca-backend/Directory.Packages.props
@@ -1,4 +1,4 @@
-<Project>
+﻿<Project>
   <ItemGroup>
     <PackageVersion Include="coverlet.collector" Version="6.0.3" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.12" />
@@ -18,8 +18,8 @@
     <PackageVersion Include="NSwag.AspNetCore" Version="14.2.0" />
     <PackageVersion Include="NSwag.MSBuild" Version="14.2.0" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
-    <PackageVersion Include="xunit" Version="2.9.3" />
-    <PackageVersion Include="xunit.abstractions" Version="2.0.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.1" />
+    <PackageVersion Include="xunit.v3" Version="2.0.0" />
+    <PackageVersion Include="xunit.v3.extensibility.core" Version="2.0.0" />
   </ItemGroup>
 </Project>

--- a/samples/Dressca/dressca-backend/Directory.Packages.props
+++ b/samples/Dressca/dressca-backend/Directory.Packages.props
@@ -1,6 +1,5 @@
 ﻿<Project>
   <ItemGroup>
-    <PackageVersion Include="coverlet.collector" Version="6.0.3" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.12" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.12" />
     <PackageVersion Include="Microsoft.AspNetCore.SpaProxy" Version="8.0.12" />
@@ -14,6 +13,7 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="8.10.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.14.2" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="NSwag.AspNetCore" Version="14.2.0" />
     <PackageVersion Include="NSwag.MSBuild" Version="14.2.0" />

--- a/samples/Dressca/dressca-backend/Dressca.sln
+++ b/samples/Dressca/dressca-backend/Dressca.sln
@@ -18,6 +18,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{16A54A4D-8AE
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{00E7327F-10DF-4937-AC61-FE2FCDCCA88B}"
+	ProjectSection(SolutionItems) = preProject
+		tests\Directory.Build.props = tests\Directory.Build.props
+	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Dressca.ApplicationCore", "src\Dressca.ApplicationCore\Dressca.ApplicationCore.csproj", "{52C22EF6-8F6D-4BC9-8D5A-33E899DD97ED}"
 EndProject

--- a/samples/Dressca/dressca-backend/src/Maris.Logging.Testing/Maris.Logging.Testing.csproj
+++ b/samples/Dressca/dressca-backend/src/Maris.Logging.Testing/Maris.Logging.Testing.csproj
@@ -7,7 +7,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit.abstractions" />
+    <PackageReference Include="xunit.v3.extensibility.core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Dressca/dressca-backend/src/Maris.Logging.Testing/Xunit/TestLoggerManager.cs
+++ b/samples/Dressca/dressca-backend/src/Maris.Logging.Testing/Xunit/TestLoggerManager.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Testing;
-using Xunit.Abstractions;
+using Xunit;
 
 namespace Maris.Logging.Testing.Xunit;
 

--- a/samples/Dressca/dressca-backend/src/Maris.Logging.Testing/Xunit/XunitLogger.cs
+++ b/samples/Dressca/dressca-backend/src/Maris.Logging.Testing/Xunit/XunitLogger.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.Extensions.Logging;
-using Xunit.Abstractions;
+using Xunit;
 
 namespace Maris.Logging.Testing.Xunit;
 

--- a/samples/Dressca/dressca-backend/src/Maris.Logging.Testing/Xunit/XunitLoggerProvider.cs
+++ b/samples/Dressca/dressca-backend/src/Maris.Logging.Testing/Xunit/XunitLoggerProvider.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.Extensions.Logging;
-using Xunit.Abstractions;
+using Xunit;
 
 namespace Maris.Logging.Testing.Xunit;
 

--- a/samples/Dressca/dressca-backend/tests/Directory.Build.props
+++ b/samples/Dressca/dressca-backend/tests/Directory.Build.props
@@ -1,0 +1,12 @@
+﻿<Project>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+  
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+  </PropertyGroup>
+
+</Project>

--- a/samples/Dressca/dressca-backend/tests/Directory.Build.props
+++ b/samples/Dressca/dressca-backend/tests/Directory.Build.props
@@ -9,4 +9,8 @@
     <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
   </PropertyGroup>
 
+   <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
 </Project>

--- a/samples/Dressca/dressca-backend/tests/Dressca.IntegrationTest/DatabaseHealthCheckTest.cs
+++ b/samples/Dressca/dressca-backend/tests/Dressca.IntegrationTest/DatabaseHealthCheckTest.cs
@@ -12,13 +12,14 @@ public class DatabaseHealthCheckTest(IntegrationTestWebApplicationFactory<Progra
     {
         // Arrange
         var client = this.factory.CreateClient();
+        var cancellationToken = TestContext.Current.CancellationToken;
 
         // Act
-        var response = await client.GetAsync("api/health");
+        var response = await client.GetAsync("api/health", cancellationToken);
 
         // Assert
         response.EnsureSuccessStatusCode();
-        var healthCheckResult = await response.Content.ReadAsStringAsync();
+        var healthCheckResult = await response.Content.ReadAsStringAsync(cancellationToken);
         Assert.Equal("Healthy", healthCheckResult);
     }
 }

--- a/samples/Dressca/dressca-backend/tests/Dressca.IntegrationTest/DatabaseHealthCheckTest.cs
+++ b/samples/Dressca/dressca-backend/tests/Dressca.IntegrationTest/DatabaseHealthCheckTest.cs
@@ -1,6 +1,4 @@
-﻿using Xunit;
-
-namespace Dressca.IntegrationTest;
+﻿namespace Dressca.IntegrationTest;
 
 public class DatabaseHealthCheckTest(IntegrationTestWebApplicationFactory<Program> factory)
     : IClassFixture<IntegrationTestWebApplicationFactory<Program>>

--- a/samples/Dressca/dressca-backend/tests/Dressca.IntegrationTest/Dressca.IntegrationTest.csproj
+++ b/samples/Dressca/dressca-backend/tests/Dressca.IntegrationTest/Dressca.IntegrationTest.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
     <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
     <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
   </PropertyGroup>

--- a/samples/Dressca/dressca-backend/tests/Dressca.IntegrationTest/Dressca.IntegrationTest.csproj
+++ b/samples/Dressca/dressca-backend/tests/Dressca.IntegrationTest/Dressca.IntegrationTest.csproj
@@ -18,7 +18,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/samples/Dressca/dressca-backend/tests/Dressca.IntegrationTest/Dressca.IntegrationTest.csproj
+++ b/samples/Dressca/dressca-backend/tests/Dressca.IntegrationTest/Dressca.IntegrationTest.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Dressca/dressca-backend/tests/Dressca.IntegrationTest/Dressca.IntegrationTest.csproj
+++ b/samples/Dressca/dressca-backend/tests/Dressca.IntegrationTest/Dressca.IntegrationTest.csproj
@@ -1,12 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <IsPackable>false</IsPackable>
-    <IsTestProject>true</IsTestProject>
-    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
-    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
-  </PropertyGroup>
-
   <ItemGroup>
     <Content Include="appsettings.IntegrationTest.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/samples/Dressca/dressca-backend/tests/Dressca.IntegrationTest/Dressca.IntegrationTest.csproj
+++ b/samples/Dressca/dressca-backend/tests/Dressca.IntegrationTest/Dressca.IntegrationTest.csproj
@@ -1,9 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <Content Include="appsettings.IntegrationTest.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
+    <Content Include="appsettings.IntegrationTest.json" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Dressca/dressca-backend/tests/Dressca.IntegrationTest/Dressca.IntegrationTest.csproj
+++ b/samples/Dressca/dressca-backend/tests/Dressca.IntegrationTest/Dressca.IntegrationTest.csproj
@@ -16,16 +16,13 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
     <PackageReference Include="StyleCop.Analyzers">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/samples/Dressca/dressca-backend/tests/Dressca.IntegrationTest/ShoppingTest.cs
+++ b/samples/Dressca/dressca-backend/tests/Dressca.IntegrationTest/ShoppingTest.cs
@@ -3,7 +3,6 @@ using System.Text;
 using System.Text.Json;
 using Dressca.Web.Consumer.Dto.Baskets;
 using Dressca.Web.Consumer.Dto.Ordering;
-using Xunit;
 
 namespace Dressca.IntegrationTest;
 

--- a/samples/Dressca/dressca-backend/tests/Dressca.IntegrationTest/ShoppingTest.cs
+++ b/samples/Dressca/dressca-backend/tests/Dressca.IntegrationTest/ShoppingTest.cs
@@ -21,9 +21,10 @@ public class ShoppingTest(IntegrationTestWebApplicationFactory<Program> factory)
         await this.factory.InitializeDatabaseAsync();
         var postBasketItemsRequest = CreateBasketItemsRequest();
         var postOrderRequestJson = JsonSerializer.Serialize(CreateDefaultPostOrderRequest());
+        var cancellationToken = TestContext.Current.CancellationToken;
 
         // Act
-        var postBasketItemResponse = await this.client.PostAsJsonAsync("api/basket-items", postBasketItemsRequest);
+        var postBasketItemResponse = await this.client.PostAsJsonAsync("api/basket-items", postBasketItemsRequest, cancellationToken);
         postBasketItemResponse.EnsureSuccessStatusCode();
 
         // API側でBuyerIdを特定できるように、Cookieを付加してリクエストする

--- a/samples/Dressca/dressca-backend/tests/Dressca.IntegrationTest/xunit.runner.json
+++ b/samples/Dressca/dressca-backend/tests/Dressca.IntegrationTest/xunit.runner.json
@@ -1,0 +1,3 @@
+﻿{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json"
+}

--- a/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.ApplicationCore/ApplicationService/AssetApplicationServiceTest.cs
+++ b/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.ApplicationCore/ApplicationService/AssetApplicationServiceTest.cs
@@ -1,6 +1,5 @@
 ﻿using Dressca.ApplicationCore.ApplicationService;
 using Dressca.ApplicationCore.Assets;
-using Xunit.Abstractions;
 
 namespace Dressca.UnitTests.ApplicationCore.ApplicationService;
 

--- a/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.ApplicationCore/ApplicationService/CatalogApplicationServiceTest.cs
+++ b/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.ApplicationCore/ApplicationService/CatalogApplicationServiceTest.cs
@@ -2,7 +2,6 @@
 using Dressca.ApplicationCore.ApplicationService;
 using Dressca.ApplicationCore.Authorization;
 using Dressca.ApplicationCore.Catalog;
-using Xunit.Abstractions;
 
 namespace Dressca.UnitTests.ApplicationCore.ApplicationService;
 

--- a/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.ApplicationCore/ApplicationService/CatalogApplicationServiceTest.cs
+++ b/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.ApplicationCore/ApplicationService/CatalogApplicationServiceTest.cs
@@ -31,9 +31,10 @@ public class CatalogApplicationServiceTest(ITestOutputHelper testOutputHelper) :
         var take = 10;
         var targetBrandId = 1;
         var targetCategoryId = 1;
+        var cancellationToken = TestContext.Current.CancellationToken;
 
         // Act
-        _ = await service.GetCatalogItemsAsync(skip, take, targetBrandId, targetCategoryId);
+        _ = await service.GetCatalogItemsAsync(skip, take, targetBrandId, targetCategoryId, cancellationToken);
 
         // Assert
         catalogRepositoryMock.Verify(
@@ -56,9 +57,10 @@ public class CatalogApplicationServiceTest(ITestOutputHelper testOutputHelper) :
         var take = 10;
         var targetBrandId = 1;
         var targetCategoryId = 1;
+        var cancellationToken = TestContext.Current.CancellationToken;
 
         // Act
-        _ = await service.GetCatalogItemsAsync(skip, take, targetBrandId, targetCategoryId);
+        _ = await service.GetCatalogItemsAsync(skip, take, targetBrandId, targetCategoryId, cancellationToken);
 
         // Assert
         catalogRepositoryMock.Verify(
@@ -77,9 +79,10 @@ public class CatalogApplicationServiceTest(ITestOutputHelper testOutputHelper) :
         var catalogDomainServiceMock = Mock.Of<ICatalogDomainService>();
         var logger = this.CreateTestLogger<CatalogApplicationService>();
         var service = new CatalogApplicationService(catalogRepository, catalogBrandRepositoryMock.Object, catalogCategoryRepository, userStore, catalogDomainServiceMock, logger);
+        var cancellationToken = TestContext.Current.CancellationToken;
 
         // Act
-        _ = await service.GetBrandsAsync();
+        _ = await service.GetBrandsAsync(cancellationToken);
 
         // Assert
         catalogBrandRepositoryMock.Verify(r => r.GetAllAsync(AnyToken), Times.Once);
@@ -97,9 +100,10 @@ public class CatalogApplicationServiceTest(ITestOutputHelper testOutputHelper) :
         var logger = this.CreateTestLogger<CatalogApplicationService>();
 
         var service = new CatalogApplicationService(catalogRepository, catalogBrandRepository, catalogCategoryRepositoryMock.Object, userStore, catalogDomainServiceMock, logger);
+        var cancellationToken = TestContext.Current.CancellationToken;
 
         // Act
-        _ = await service.GetCategoriesAsync();
+        _ = await service.GetCategoriesAsync(cancellationToken);
 
         // Assert
         catalogCategoryRepositoryMock.Verify(r => r.GetAllAsync(AnyToken), Times.Once);
@@ -129,6 +133,7 @@ public class CatalogApplicationServiceTest(ITestOutputHelper testOutputHelper) :
 
         var logger = this.CreateTestLogger<CatalogApplicationService>();
         var service = new CatalogApplicationService(catalogRepositoryMock.Object, catalogBrandRepositoryMock, catalogCategoryRepositoryMock, userStoreMock.Object, catalogDomainServiceMock.Object, logger);
+        var cancellationToken = TestContext.Current.CancellationToken;
 
         // Assert
         await service.AddItemToCatalogAsync(
@@ -137,7 +142,8 @@ public class CatalogApplicationServiceTest(ITestOutputHelper testOutputHelper) :
             targetPrice,
             targetProductCode,
             targetBrandId,
-            targetCategoryId);
+            targetCategoryId,
+            cancellationToken);
 
         // Act
         catalogRepositoryMock.Verify(r => r.AddAsync(It.IsAny<CatalogItem>(), AnyToken), Times.Once);
@@ -176,6 +182,7 @@ public class CatalogApplicationServiceTest(ITestOutputHelper testOutputHelper) :
 
         var logger = this.CreateTestLogger<CatalogApplicationService>();
         var service = new CatalogApplicationService(catalogRepositoryMock.Object, catalogBrandRepositoryMock, catalogCategoryRepositoryMock, userStoreMock.Object, catalogDomainServiceMock.Object, logger);
+        var cancellationToken = TestContext.Current.CancellationToken;
 
         // Assert
         var actual = await service.AddItemToCatalogAsync(
@@ -184,7 +191,8 @@ public class CatalogApplicationServiceTest(ITestOutputHelper testOutputHelper) :
             targetPrice,
             targetProductCode,
             targetBrandId,
-            targetCategoryId);
+            targetCategoryId,
+            cancellationToken);
 
         // Act
         Assert.Same(targetItem, actual);
@@ -314,9 +322,10 @@ public class CatalogApplicationServiceTest(ITestOutputHelper testOutputHelper) :
         userStoreMock.Setup(a => a.IsInRole(It.IsAny<string>())).Returns(true);
         var logger = this.CreateTestLogger<CatalogApplicationService>();
         var service = new CatalogApplicationService(catalogRepositoryMock.Object, catalogBrandRepositoryMock, catalogCategoryRepositoryMock, userStoreMock.Object, catalogDomainServiceMock.Object, logger);
+        var cancellationToken = TestContext.Current.CancellationToken;
 
         // Act
-        await service.DeleteItemFromCatalogAsync(targetId, targetRowVersion);
+        await service.DeleteItemFromCatalogAsync(targetId, targetRowVersion, cancellationToken);
 
         // Assert
         catalogRepositoryMock.Verify(r => r.RemoveAsync(targetId, targetRowVersion, AnyToken), Times.Once);
@@ -408,6 +417,7 @@ public class CatalogApplicationServiceTest(ITestOutputHelper testOutputHelper) :
         catalogDomainServiceMock.Setup(s => s.CategoryExistsAsync(targetCategoryId, AnyToken)).ReturnsAsync(true);
         var logger = this.CreateTestLogger<CatalogApplicationService>();
         var service = new CatalogApplicationService(catalogRepositoryMock.Object, catalogBrandRepositoryMock.Object, catalogCategoryRepositoryMock.Object, userStoreMock.Object, catalogDomainServiceMock.Object, logger);
+        var cancellationToken = TestContext.Current.CancellationToken;
 
         // Act
         await service.UpdateCatalogItemAsync(
@@ -418,7 +428,8 @@ public class CatalogApplicationServiceTest(ITestOutputHelper testOutputHelper) :
             targetProductCode,
             targetBrandId,
             targetCategoryId,
-            AnyRowVersion);
+            AnyRowVersion,
+            cancellationToken);
 
         // Assert
         catalogRepositoryMock.Verify(r => r.UpdateAsync(It.IsAny<CatalogItem>(), AnyToken), Times.Once);
@@ -632,9 +643,10 @@ public class CatalogApplicationServiceTest(ITestOutputHelper testOutputHelper) :
         var take = 10;
         var targetBrandId = 1;
         var targetCategoryId = 1;
+        var cancellationToken = TestContext.Current.CancellationToken;
 
         // Act
-        _ = await service.GetCatalogItemsForAdminAsync(skip, take, targetBrandId, targetCategoryId);
+        _ = await service.GetCatalogItemsForAdminAsync(skip, take, targetBrandId, targetCategoryId, cancellationToken);
 
         // Assert
         catalogRepositoryMock.Verify(
@@ -658,9 +670,10 @@ public class CatalogApplicationServiceTest(ITestOutputHelper testOutputHelper) :
         var take = 10;
         var targetBrandId = 1;
         var targetCategoryId = 1;
+        var cancellationToken = TestContext.Current.CancellationToken;
 
         // Act
-        _ = await service.GetCatalogItemsForAdminAsync(skip, take, targetBrandId, targetCategoryId);
+        _ = await service.GetCatalogItemsForAdminAsync(skip, take, targetBrandId, targetCategoryId, cancellationToken);
 
         // Assert
         catalogRepositoryMock.Verify(
@@ -690,9 +703,10 @@ public class CatalogApplicationServiceTest(ITestOutputHelper testOutputHelper) :
         var catalogDomainServiceMock = Mock.Of<ICatalogDomainService>();
         var logger = this.CreateTestLogger<CatalogApplicationService>();
         var service = new CatalogApplicationService(catalogRepositoryMock.Object, catalogBrandRepositoryMock.Object, catalogCategoryRepositoryMock.Object, userStoreMock.Object, catalogDomainServiceMock, logger);
+        var cancellationToken = TestContext.Current.CancellationToken;
 
         // Act
-        var (list, totalItems) = await service.GetCatalogItemsForAdminAsync(skip, take, targetBrandId, targetCategoryId);
+        var (list, totalItems) = await service.GetCatalogItemsForAdminAsync(skip, take, targetBrandId, targetCategoryId, cancellationToken);
 
         // Assert
         Assert.Equal(targetItems, list);
@@ -740,9 +754,10 @@ public class CatalogApplicationServiceTest(ITestOutputHelper testOutputHelper) :
         userStoreMock.Setup(a => a.IsInRole(It.IsAny<string>())).Returns(true);
         var logger = this.CreateTestLogger<CatalogApplicationService>();
         var service = new CatalogApplicationService(catalogRepositoryMock.Object, catalogBrandRepository, catalogCategoryRepository, userStoreMock.Object, catalogDomainServiceMock, logger);
+        var cancellationToken = TestContext.Current.CancellationToken;
 
         // Act
-        _ = await service.GetCatalogItemForAdminAsync(targetId);
+        _ = await service.GetCatalogItemForAdminAsync(targetId, cancellationToken);
 
         // Assert
         catalogRepositoryMock.Verify(r => r.GetAsync(targetId, AnyToken), Times.Once);

--- a/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.ApplicationCore/ApplicationService/OrderApplicationServiceTest.cs
+++ b/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.ApplicationCore/ApplicationService/OrderApplicationServiceTest.cs
@@ -26,9 +26,10 @@ public class OrderApplicationServiceTest(ITestOutputHelper testOutputHelper) : T
         var catalogRepository = Mock.Of<ICatalogRepository>();
         var logger = this.CreateTestLogger<OrderApplicationService>();
         var service = new OrderApplicationService(orderRepositoryMock.Object, logger);
+        var cancellationToken = TestContext.Current.CancellationToken;
 
         // Act
-        var actual = await service.GetOrderAsync(orderId, buyerId);
+        var actual = await service.GetOrderAsync(orderId, buyerId, cancellationToken);
 
         // Assert
         Assert.Same(order, actual);
@@ -51,9 +52,10 @@ public class OrderApplicationServiceTest(ITestOutputHelper testOutputHelper) : T
         var catalogRepository = Mock.Of<ICatalogRepository>();
         var logger = this.CreateTestLogger<OrderApplicationService>();
         var service = new OrderApplicationService(orderRepositoryMock.Object, logger);
+        var cancellationToken = TestContext.Current.CancellationToken;
 
         // Act
-        var actual = await service.GetOrderAsync(orderId, buyerId);
+        var actual = await service.GetOrderAsync(orderId, buyerId, cancellationToken);
 
         // Assert
         orderRepositoryMock.Verify(r => r.FindAsync(orderId, AnyToken), Times.Once);

--- a/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.ApplicationCore/ApplicationService/OrderApplicationServiceTest.cs
+++ b/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.ApplicationCore/ApplicationService/OrderApplicationServiceTest.cs
@@ -2,7 +2,6 @@
 using Dressca.ApplicationCore.Baskets;
 using Dressca.ApplicationCore.Catalog;
 using Dressca.ApplicationCore.Ordering;
-using Xunit.Abstractions;
 
 namespace Dressca.UnitTests.ApplicationCore.ApplicationService;
 

--- a/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.ApplicationCore/ApplicationService/ShoppingApplicationServiceTest.cs
+++ b/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.ApplicationCore/ApplicationService/ShoppingApplicationServiceTest.cs
@@ -57,9 +57,10 @@ public class ShoppingApplicationServiceTest(ITestOutputHelper testOutputHelper) 
         var catalogDomainService = Mock.Of<ICatalogDomainService>();
         var logger = this.CreateTestLogger<ShoppingApplicationService>();
         var service = new ShoppingApplicationService(basketRepo.Object, orderRepo, orderFactory, catalogRepo.Object, catalogDomainService, logger);
+        var cancellationToken = TestContext.Current.CancellationToken;
 
         // Act
-        await service.GetBasketItemsAsync(dummyBuyerId);
+        await service.GetBasketItemsAsync(dummyBuyerId, cancellationToken);
 
         // Assert
         catalogRepo.Verify(
@@ -91,9 +92,10 @@ public class ShoppingApplicationServiceTest(ITestOutputHelper testOutputHelper) 
         var catalogDomainService = Mock.Of<ICatalogDomainService>();
         var logger = this.CreateTestLogger<ShoppingApplicationService>();
         var service = new ShoppingApplicationService(basketRepo.Object, orderRepo, orderFactory, catalogRepo.Object, catalogDomainService, logger);
+        var cancellationToken = TestContext.Current.CancellationToken;
 
         // Act
-        await service.GetBasketItemsAsync(dummyBuyerId);
+        await service.GetBasketItemsAsync(dummyBuyerId, cancellationToken);
 
         // Assert
         basketRepo.Verify(r => r.GetWithBasketItemsAsync(dummyBuyerId, AnyToken), Times.Once);
@@ -123,9 +125,10 @@ public class ShoppingApplicationServiceTest(ITestOutputHelper testOutputHelper) 
         var catalogDomainService = Mock.Of<ICatalogDomainService>();
         var logger = this.CreateTestLogger<ShoppingApplicationService>();
         var service = new ShoppingApplicationService(basketRepo.Object, orderRepo, orderFactory, catalogRepo.Object, catalogDomainService, logger);
+        var cancellationToken = TestContext.Current.CancellationToken;
 
         // Act
-        await service.GetBasketItemsAsync(dummyBuyerId);
+        await service.GetBasketItemsAsync(dummyBuyerId, cancellationToken);
 
         // Assert
         basketRepo.Verify(r => r.AddAsync(It.Is<Basket>(b => b.BuyerId == dummyBuyerId), AnyToken), Times.Once);
@@ -237,9 +240,10 @@ public class ShoppingApplicationServiceTest(ITestOutputHelper testOutputHelper) 
             .ReturnsAsync((true, catalogItems.AsReadOnly()));
         var logger = this.CreateTestLogger<ShoppingApplicationService>();
         var service = new ShoppingApplicationService(basketRepo.Object, orderRepo, orderFactory, catalogRepo, catalogDomainService.Object, logger);
+        var cancellationToken = TestContext.Current.CancellationToken;
 
         // Act
-        await service.SetBasketItemsQuantitiesAsync(dummyBuyerId, quantities);
+        await service.SetBasketItemsQuantitiesAsync(dummyBuyerId, quantities, cancellationToken);
 
         // Assert
         basketRepo.Verify(
@@ -274,9 +278,10 @@ public class ShoppingApplicationServiceTest(ITestOutputHelper testOutputHelper) 
             .ReturnsAsync((true, catalogItems.AsReadOnly()));
         var logger = this.CreateTestLogger<ShoppingApplicationService>();
         var service = new ShoppingApplicationService(basketRepo.Object, orderRepo, orderFactory, catalogRepo, catalogDomainService.Object, logger);
+        var cancellationToken = TestContext.Current.CancellationToken;
 
         // Act
-        await service.SetBasketItemsQuantitiesAsync(dummyBuyerId, quantities);
+        await service.SetBasketItemsQuantitiesAsync(dummyBuyerId, quantities, cancellationToken);
 
         // Assert
         basketRepo.Verify(
@@ -310,9 +315,10 @@ public class ShoppingApplicationServiceTest(ITestOutputHelper testOutputHelper) 
             .ReturnsAsync((true, catalogItems.AsReadOnly()));
         var logger = this.CreateTestLogger<ShoppingApplicationService>();
         var service = new ShoppingApplicationService(basketRepo.Object, orderRepo, orderFactory, catalogRepo, catalogDomainService.Object, logger);
+        var cancellationToken = TestContext.Current.CancellationToken;
 
         // Act
-        await service.SetBasketItemsQuantitiesAsync(dummyBuyerId, quantities);
+        await service.SetBasketItemsQuantitiesAsync(dummyBuyerId, quantities, cancellationToken);
 
         // Assert
         basketRepo.Verify(
@@ -397,9 +403,10 @@ public class ShoppingApplicationServiceTest(ITestOutputHelper testOutputHelper) 
             .ReturnsAsync((true, catalogItems.AsReadOnly()));
         var logger = this.CreateTestLogger<ShoppingApplicationService>();
         var service = new ShoppingApplicationService(basketRepo.Object, orderRepo, orderFactory, catalogRepo, catalogDomainService.Object, logger);
+        var cancellationToken = TestContext.Current.CancellationToken;
 
         // Act
-        await service.AddItemToBasketAsync(dummyBuyerId, 10L, 5);
+        await service.AddItemToBasketAsync(dummyBuyerId, 10L, 5, cancellationToken);
 
         // Assert
         basketRepo.Verify(
@@ -430,9 +437,10 @@ public class ShoppingApplicationServiceTest(ITestOutputHelper testOutputHelper) 
             .ReturnsAsync((true, catalogItems.AsReadOnly()));
         var logger = this.CreateTestLogger<ShoppingApplicationService>();
         var service = new ShoppingApplicationService(basketRepo.Object, orderRepo, orderFactory, catalogRepo, catalogDomainService.Object, logger);
+        var cancellationToken = TestContext.Current.CancellationToken;
 
         // Act
-        await service.AddItemToBasketAsync(dummyBuyerId, 10L, 5);
+        await service.AddItemToBasketAsync(dummyBuyerId, 10L, 5, cancellationToken);
 
         // Assert
         basketRepo.Verify(
@@ -565,9 +573,10 @@ public class ShoppingApplicationServiceTest(ITestOutputHelper testOutputHelper) 
         var catalogDomainService = Mock.Of<ICatalogDomainService>();
         var logger = this.CreateTestLogger<ShoppingApplicationService>();
         var service = new ShoppingApplicationService(basketRepo.Object, orderRepo.Object, orderFactory.Object, catalogRepo.Object, catalogDomainService, logger);
+        var cancellationToken = TestContext.Current.CancellationToken;
 
         // Act
-        await service.CheckoutAsync(dummyBuyerId, shipTo);
+        await service.CheckoutAsync(dummyBuyerId, shipTo, cancellationToken);
 
         // Assert
         catalogRepo.Verify(
@@ -611,9 +620,10 @@ public class ShoppingApplicationServiceTest(ITestOutputHelper testOutputHelper) 
         var catalogDomainService = Mock.Of<ICatalogDomainService>();
         var logger = this.CreateTestLogger<ShoppingApplicationService>();
         var service = new ShoppingApplicationService(basketRepo.Object, orderRepo.Object, orderFactory.Object, catalogRepo.Object, catalogDomainService, logger);
+        var cancellationToken = TestContext.Current.CancellationToken;
 
         // Act
-        await service.CheckoutAsync(dummyBuyerId, shipTo);
+        await service.CheckoutAsync(dummyBuyerId, shipTo, cancellationToken);
 
         // Assert
         orderRepo.Verify(
@@ -657,9 +667,10 @@ public class ShoppingApplicationServiceTest(ITestOutputHelper testOutputHelper) 
         var catalogDomainService = Mock.Of<ICatalogDomainService>();
         var logger = this.CreateTestLogger<ShoppingApplicationService>();
         var service = new ShoppingApplicationService(basketRepo.Object, orderRepo.Object, orderFactory.Object, catalogRepo.Object, catalogDomainService, logger);
+        var cancellationToken = TestContext.Current.CancellationToken;
 
         // Act
-        await service.CheckoutAsync(dummyBuyerId, shipTo);
+        await service.CheckoutAsync(dummyBuyerId, shipTo, cancellationToken);
 
         // Assert
         orderRepo.Verify(
@@ -703,9 +714,10 @@ public class ShoppingApplicationServiceTest(ITestOutputHelper testOutputHelper) 
         var catalogDomainService = Mock.Of<ICatalogDomainService>();
         var logger = this.CreateTestLogger<ShoppingApplicationService>();
         var service = new ShoppingApplicationService(basketRepo.Object, orderRepo.Object, orderFactory.Object, catalogRepo.Object, catalogDomainService, logger);
+        var cancellationToken = TestContext.Current.CancellationToken;
 
         // Act
-        await service.CheckoutAsync(dummyBuyerId, shipTo);
+        await service.CheckoutAsync(dummyBuyerId, shipTo, cancellationToken);
 
         // Assert
         orderRepo.Verify(
@@ -764,9 +776,10 @@ public class ShoppingApplicationServiceTest(ITestOutputHelper testOutputHelper) 
         var catalogDomainService = Mock.Of<ICatalogDomainService>();
         var logger = this.CreateTestLogger<ShoppingApplicationService>();
         var service = new ShoppingApplicationService(basketRepo.Object, orderRepo.Object, orderFactory.Object, catalogRepo.Object, catalogDomainService, logger);
+        var cancellationToken = TestContext.Current.CancellationToken;
 
         // Act
-        await service.CheckoutAsync(dummyBuyerId, shipTo);
+        await service.CheckoutAsync(dummyBuyerId, shipTo, cancellationToken);
 
         // Assert
         basketRepo.Verify(

--- a/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.ApplicationCore/ApplicationService/ShoppingApplicationServiceTest.cs
+++ b/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.ApplicationCore/ApplicationService/ShoppingApplicationServiceTest.cs
@@ -3,7 +3,6 @@ using Dressca.ApplicationCore.ApplicationService;
 using Dressca.ApplicationCore.Baskets;
 using Dressca.ApplicationCore.Catalog;
 using Dressca.ApplicationCore.Ordering;
-using Xunit.Abstractions;
 
 namespace Dressca.UnitTests.ApplicationCore.ApplicationService;
 

--- a/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.ApplicationCore/Catalog/CatalogDomainServiceTest.cs
+++ b/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.ApplicationCore/Catalog/CatalogDomainServiceTest.cs
@@ -26,9 +26,10 @@ public class CatalogDomainServiceTest(ITestOutputHelper testOutputHelper) : Test
 
         var logger = this.CreateTestLogger<CatalogDomainService>();
         var domainService = new CatalogDomainService(catalogRepositoryMock.Object, catalogBrandRepositoryMock, catalogCategoryRepositoryMock, logger);
+        var cancellationToken = TestContext.Current.CancellationToken;
 
         // Act
-        var (existsAll, items) = await domainService.ExistsAllAsync([1L, 2L]);
+        var (existsAll, items) = await domainService.ExistsAllAsync([1L, 2L], cancellationToken);
 
         // Assert
         Assert.True(existsAll);
@@ -55,9 +56,10 @@ public class CatalogDomainServiceTest(ITestOutputHelper testOutputHelper) : Test
 
         var logger = this.CreateTestLogger<CatalogDomainService>();
         var domainService = new CatalogDomainService(catalogRepositoryMock.Object, catalogBrandRepositoryMock, catalogCategoryRepositoryMock, logger);
+        var cancellationToken = TestContext.Current.CancellationToken;
 
         // Act
-        var (existsAll, items) = await domainService.ExistsAllAsync([1L, 2L]);
+        var (existsAll, items) = await domainService.ExistsAllAsync([1L, 2L], cancellationToken);
 
         // Assert
         Assert.False(existsAll);
@@ -81,9 +83,10 @@ public class CatalogDomainServiceTest(ITestOutputHelper testOutputHelper) : Test
 
         var logger = this.CreateTestLogger<CatalogDomainService>();
         var domainService = new CatalogDomainService(catalogRepositoryMock.Object, catalogBrandRepositoryMock, catalogCategoryRepositoryMock, logger);
+        var cancellationToken = TestContext.Current.CancellationToken;
 
         // Act
-        _ = await domainService.ExistsAllAsync([1L, 2L]);
+        _ = await domainService.ExistsAllAsync([1L, 2L], cancellationToken);
 
         // Assert
         Assert.Equal(1, this.LogCollector.Count);
@@ -107,9 +110,10 @@ public class CatalogDomainServiceTest(ITestOutputHelper testOutputHelper) : Test
 
         var logger = this.CreateTestLogger<CatalogDomainService>();
         var domainService = new CatalogDomainService(catalogRepositoryMock.Object, catalogBrandRepositoryMock, catalogCategoryRepositoryMock, logger);
+        var cancellationToken = TestContext.Current.CancellationToken;
 
         // Act
-        var (existsAll, items) = await domainService.ExistsAllAsync([1L]);
+        var (existsAll, items) = await domainService.ExistsAllAsync([1L], cancellationToken);
 
         // Assert
         Assert.False(existsAll);
@@ -130,9 +134,10 @@ public class CatalogDomainServiceTest(ITestOutputHelper testOutputHelper) : Test
 
         var logger = this.CreateTestLogger<CatalogDomainService>();
         var domainService = new CatalogDomainService(catalogRepositoryMock.Object, catalogBrandRepositoryMock, catalogCategoryRepositoryMock, logger);
+        var cancellationToken = TestContext.Current.CancellationToken;
 
         // Act
-        _ = await domainService.ExistsAllAsync([1L]);
+        _ = await domainService.ExistsAllAsync([1L], cancellationToken);
 
         // Assert
         Assert.Equal(1, this.LogCollector.Count);
@@ -156,9 +161,10 @@ public class CatalogDomainServiceTest(ITestOutputHelper testOutputHelper) : Test
         catalogRepositoryMock
             .Setup(r => r.AnyAsync(targetItemId, AnyToken))
             .ReturnsAsync(true);
+        var cancellationToken = TestContext.Current.CancellationToken;
 
         // Act
-        var result = await domainService.ItemExistsAsync(targetItemId);
+        var result = await domainService.ItemExistsAsync(targetItemId, cancellationToken);
 
         // Assert
         Assert.True(result);
@@ -178,9 +184,10 @@ public class CatalogDomainServiceTest(ITestOutputHelper testOutputHelper) : Test
         catalogRepositoryMock
             .Setup(r => r.AnyAsync(targetItemId, AnyToken))
             .ReturnsAsync(false);
+        var cancellationToken = TestContext.Current.CancellationToken;
 
         // Act
-        var result = await domainService.ItemExistsAsync(targetItemId);
+        var result = await domainService.ItemExistsAsync(targetItemId, cancellationToken);
 
         // Assert
         Assert.False(result);
@@ -200,9 +207,10 @@ public class CatalogDomainServiceTest(ITestOutputHelper testOutputHelper) : Test
         catalogBrandRepositoryMock
             .Setup(r => r.AnyAsync(targetBrandId, AnyToken))
             .ReturnsAsync(true);
+        var cancellationToken = TestContext.Current.CancellationToken;
 
         // Act
-        var result = await domainService.BrandExistsAsync(targetBrandId);
+        var result = await domainService.BrandExistsAsync(targetBrandId, cancellationToken);
 
         // Assert
         Assert.True(result);
@@ -222,9 +230,10 @@ public class CatalogDomainServiceTest(ITestOutputHelper testOutputHelper) : Test
         catalogBrandRepositoryMock
             .Setup(r => r.AnyAsync(targetBrandId, AnyToken))
             .ReturnsAsync(false);
+        var cancellationToken = TestContext.Current.CancellationToken;
 
         // Act
-        var result = await domainService.BrandExistsAsync(targetBrandId);
+        var result = await domainService.BrandExistsAsync(targetBrandId, cancellationToken);
 
         // Assert
         Assert.False(result);
@@ -244,9 +253,10 @@ public class CatalogDomainServiceTest(ITestOutputHelper testOutputHelper) : Test
         catalogCategoryRepositoryMock
             .Setup(r => r.AnyAsync(targetCategoryId, AnyToken))
             .ReturnsAsync(true);
+        var cancellationToken = TestContext.Current.CancellationToken;
 
         // Act
-        var result = await domainService.CategoryExistsAsync(targetCategoryId);
+        var result = await domainService.CategoryExistsAsync(targetCategoryId, cancellationToken);
 
         // Assert
         Assert.True(result);
@@ -266,9 +276,10 @@ public class CatalogDomainServiceTest(ITestOutputHelper testOutputHelper) : Test
         catalogCategoryRepositoryMock
             .Setup(r => r.AnyAsync(targetCategoryId, AnyToken))
             .ReturnsAsync(false);
+        var cancellationToken = TestContext.Current.CancellationToken;
 
         // Act
-        var result = await domainService.CategoryExistsAsync(targetCategoryId);
+        var result = await domainService.CategoryExistsAsync(targetCategoryId, cancellationToken);
 
         // Assert
         Assert.False(result);

--- a/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.ApplicationCore/Catalog/CatalogDomainServiceTest.cs
+++ b/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.ApplicationCore/Catalog/CatalogDomainServiceTest.cs
@@ -1,7 +1,6 @@
 ﻿using System.Linq.Expressions;
 using Dressca.ApplicationCore.Catalog;
 using Microsoft.Extensions.Logging;
-using Xunit.Abstractions;
 
 namespace Dressca.UnitTests.ApplicationCore.Catalog;
 

--- a/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.ApplicationCore/Dressca.UnitTests.ApplicationCore.csproj
+++ b/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.ApplicationCore/Dressca.UnitTests.ApplicationCore.csproj
@@ -1,6 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
+    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Using Include="Moq" />
   </ItemGroup>
 

--- a/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.ApplicationCore/Dressca.UnitTests.ApplicationCore.csproj
+++ b/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.ApplicationCore/Dressca.UnitTests.ApplicationCore.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <Using Include="Xunit" />
     <Using Include="Moq" />
   </ItemGroup>
 

--- a/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.ApplicationCore/Dressca.UnitTests.ApplicationCore.csproj
+++ b/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.ApplicationCore/Dressca.UnitTests.ApplicationCore.csproj
@@ -1,12 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <IsPackable>false</IsPackable>
-    <IsTestProject>true</IsTestProject>
-    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
-    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
-  </PropertyGroup>
-
   <ItemGroup>
     <Using Include="Xunit" />
     <Using Include="Moq" />

--- a/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.ApplicationCore/Dressca.UnitTests.ApplicationCore.csproj
+++ b/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.ApplicationCore/Dressca.UnitTests.ApplicationCore.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
     <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
     <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
   </PropertyGroup>

--- a/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.ApplicationCore/Dressca.UnitTests.ApplicationCore.csproj
+++ b/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.ApplicationCore/Dressca.UnitTests.ApplicationCore.csproj
@@ -1,7 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.ApplicationCore/Dressca.UnitTests.ApplicationCore.csproj
+++ b/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.ApplicationCore/Dressca.UnitTests.ApplicationCore.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
     <PackageReference Include="Moq" />
     <PackageReference Include="StyleCop.Analyzers">
       <PrivateAssets>all</PrivateAssets>
@@ -21,10 +22,6 @@
     </PackageReference>
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.ApplicationCore/Dressca.UnitTests.ApplicationCore.csproj
+++ b/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.ApplicationCore/Dressca.UnitTests.ApplicationCore.csproj
@@ -17,7 +17,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.ApplicationCore/Ordering/OrderTest.cs
+++ b/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.ApplicationCore/Ordering/OrderTest.cs
@@ -7,7 +7,7 @@ public class OrderTest
 {
     public static TheoryData<List<OrderItem>?> EmptyOrderItems => new()
     {
-        null,
+        (List<OrderItem>?)null,
         new List<OrderItem>(),
     };
 

--- a/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.ApplicationCore/TestBase.cs
+++ b/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.ApplicationCore/TestBase.cs
@@ -1,7 +1,6 @@
 ﻿using Maris.Logging.Testing.Xunit;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Testing;
-using Xunit.Abstractions;
 
 namespace Dressca.UnitTests.ApplicationCore;
 

--- a/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.ApplicationCore/xunit.runner.json
+++ b/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.ApplicationCore/xunit.runner.json
@@ -1,0 +1,3 @@
+﻿{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json"
+}

--- a/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.SystemCommon/Dressca.UnitTests.SystemCommon.csproj
+++ b/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.SystemCommon/Dressca.UnitTests.SystemCommon.csproj
@@ -1,6 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
+    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Using Include="Moq" />
   </ItemGroup>
 

--- a/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.SystemCommon/Dressca.UnitTests.SystemCommon.csproj
+++ b/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.SystemCommon/Dressca.UnitTests.SystemCommon.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <Using Include="Xunit" />
     <Using Include="Moq" />
   </ItemGroup>
 

--- a/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.SystemCommon/Dressca.UnitTests.SystemCommon.csproj
+++ b/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.SystemCommon/Dressca.UnitTests.SystemCommon.csproj
@@ -1,12 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <IsPackable>false</IsPackable>
-    <IsTestProject>true</IsTestProject>
-    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
-    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
-  </PropertyGroup>
-
   <ItemGroup>
     <Using Include="Xunit" />
     <Using Include="Moq" />

--- a/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.SystemCommon/Dressca.UnitTests.SystemCommon.csproj
+++ b/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.SystemCommon/Dressca.UnitTests.SystemCommon.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
     <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
     <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
   </PropertyGroup>

--- a/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.SystemCommon/Dressca.UnitTests.SystemCommon.csproj
+++ b/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.SystemCommon/Dressca.UnitTests.SystemCommon.csproj
@@ -1,7 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.SystemCommon/Dressca.UnitTests.SystemCommon.csproj
+++ b/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.SystemCommon/Dressca.UnitTests.SystemCommon.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
     <PackageReference Include="Moq" />
     <PackageReference Include="StyleCop.Analyzers">
       <PrivateAssets>all</PrivateAssets>
@@ -20,10 +21,6 @@
     </PackageReference>
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.SystemCommon/Dressca.UnitTests.SystemCommon.csproj
+++ b/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.SystemCommon/Dressca.UnitTests.SystemCommon.csproj
@@ -16,7 +16,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.SystemCommon/xunit.runner.json
+++ b/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.SystemCommon/xunit.runner.json
@@ -1,0 +1,3 @@
+﻿{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json"
+}

--- a/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.Web.Admin/Dressca.UnitTests.Web.Admin.csproj
+++ b/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.Web.Admin/Dressca.UnitTests.Web.Admin.csproj
@@ -20,8 +20,4 @@
     <ProjectReference Include="..\..\src\Maris.Logging.Testing\Maris.Logging.Testing.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Using Include="Xunit" />
-  </ItemGroup>
-
 </Project>

--- a/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.Web.Admin/Dressca.UnitTests.Web.Admin.csproj
+++ b/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.Web.Admin/Dressca.UnitTests.Web.Admin.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
     <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
     <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
   </PropertyGroup>

--- a/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.Web.Admin/Dressca.UnitTests.Web.Admin.csproj
+++ b/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.Web.Admin/Dressca.UnitTests.Web.Admin.csproj
@@ -1,6 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
+    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
     <PackageReference Include="Moq" />

--- a/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.Web.Admin/Dressca.UnitTests.Web.Admin.csproj
+++ b/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.Web.Admin/Dressca.UnitTests.Web.Admin.csproj
@@ -1,7 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.Web.Admin/Dressca.UnitTests.Web.Admin.csproj
+++ b/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.Web.Admin/Dressca.UnitTests.Web.Admin.csproj
@@ -11,7 +11,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.Web.Admin/Dressca.UnitTests.Web.Admin.csproj
+++ b/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.Web.Admin/Dressca.UnitTests.Web.Admin.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
     <PackageReference Include="Moq" />
     <PackageReference Include="StyleCop.Analyzers">
       <PrivateAssets>all</PrivateAssets>
@@ -15,10 +16,6 @@
     </PackageReference>
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.Web.Admin/Dressca.UnitTests.Web.Admin.csproj
+++ b/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.Web.Admin/Dressca.UnitTests.Web.Admin.csproj
@@ -1,12 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <IsPackable>false</IsPackable>
-    <IsTestProject>true</IsTestProject>
-    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
-    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />

--- a/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.Web.Admin/DummyTest.cs
+++ b/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.Web.Admin/DummyTest.cs
@@ -1,9 +1,13 @@
-﻿namespace Dressca.UnitTests.Web.Admin;
+﻿// このテストクラスは、ダミーのテストクラスです。
+// テストプロジェクトにテストが 1 つもないと、テスト結果が失敗するため、このクラスを追加しました。
+// テストを追加したら、このクラスを削除してください。
+
+namespace Dressca.UnitTests.Web.Admin;
 
 public class DummyTest
 {
     [Fact]
-    public void Test1()
+    public void DummyTest1()
     {
     }
 }

--- a/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.Web.Admin/DummyTest.cs
+++ b/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.Web.Admin/DummyTest.cs
@@ -1,0 +1,9 @@
+﻿namespace Dressca.UnitTests.Web.Admin;
+
+public class DummyTest
+{
+    [Fact]
+    public void Test1()
+    {
+    }
+}

--- a/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.Web.Admin/TestBase.cs
+++ b/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.Web.Admin/TestBase.cs
@@ -1,7 +1,6 @@
 ﻿using Maris.Logging.Testing.Xunit;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Testing;
-using Xunit.Abstractions;
 
 namespace Dressca.UnitTests.Web.Admin;
 

--- a/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.Web.Admin/xunit.runner.json
+++ b/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.Web.Admin/xunit.runner.json
@@ -1,0 +1,3 @@
+﻿{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json"
+}

--- a/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.Web.Consumer/Dressca.UnitTests.Web.Consumer.csproj
+++ b/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.Web.Consumer/Dressca.UnitTests.Web.Consumer.csproj
@@ -1,6 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
+    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Using Include="Moq" />
   </ItemGroup>
 

--- a/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.Web.Consumer/Dressca.UnitTests.Web.Consumer.csproj
+++ b/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.Web.Consumer/Dressca.UnitTests.Web.Consumer.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <Using Include="Xunit" />
     <Using Include="Moq" />
   </ItemGroup>
 

--- a/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.Web.Consumer/Dressca.UnitTests.Web.Consumer.csproj
+++ b/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.Web.Consumer/Dressca.UnitTests.Web.Consumer.csproj
@@ -1,12 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <IsPackable>false</IsPackable>
-    <IsTestProject>true</IsTestProject>
-    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
-    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
-  </PropertyGroup>
-
   <ItemGroup>
     <Using Include="Xunit" />
     <Using Include="Moq" />

--- a/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.Web.Consumer/Dressca.UnitTests.Web.Consumer.csproj
+++ b/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.Web.Consumer/Dressca.UnitTests.Web.Consumer.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
     <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
     <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
   </PropertyGroup>

--- a/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.Web.Consumer/Dressca.UnitTests.Web.Consumer.csproj
+++ b/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.Web.Consumer/Dressca.UnitTests.Web.Consumer.csproj
@@ -1,7 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.Web.Consumer/Dressca.UnitTests.Web.Consumer.csproj
+++ b/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.Web.Consumer/Dressca.UnitTests.Web.Consumer.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
     <PackageReference Include="Moq" />
     <PackageReference Include="StyleCop.Analyzers">
       <PrivateAssets>all</PrivateAssets>
@@ -21,10 +22,6 @@
     </PackageReference>
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.Web.Consumer/Dressca.UnitTests.Web.Consumer.csproj
+++ b/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.Web.Consumer/Dressca.UnitTests.Web.Consumer.csproj
@@ -17,7 +17,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.Web.Consumer/TestBase.cs
+++ b/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.Web.Consumer/TestBase.cs
@@ -1,7 +1,6 @@
 ﻿using Maris.Logging.Testing.Xunit;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Testing;
-using Xunit.Abstractions;
 
 namespace Dressca.UnitTests.Web.Consumer;
 

--- a/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.Web.Consumer/xunit.runner.json
+++ b/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.Web.Consumer/xunit.runner.json
@@ -1,0 +1,3 @@
+﻿{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json"
+}

--- a/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.Web/Dressca.UnitTests.Web.csproj
+++ b/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.Web/Dressca.UnitTests.Web.csproj
@@ -1,6 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
+    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
     <PackageReference Include="StyleCop.Analyzers">

--- a/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.Web/Dressca.UnitTests.Web.csproj
+++ b/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.Web/Dressca.UnitTests.Web.csproj
@@ -15,7 +15,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.Web/Dressca.UnitTests.Web.csproj
+++ b/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.Web/Dressca.UnitTests.Web.csproj
@@ -1,12 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <IsPackable>false</IsPackable>
-    <IsTestProject>true</IsTestProject>
-    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
-    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
-  </PropertyGroup>
-
   <ItemGroup>
     <Using Include="Xunit" />
   </ItemGroup>

--- a/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.Web/Dressca.UnitTests.Web.csproj
+++ b/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.Web/Dressca.UnitTests.Web.csproj
@@ -1,10 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <Using Include="Xunit" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
     <PackageReference Include="StyleCop.Analyzers">

--- a/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.Web/Dressca.UnitTests.Web.csproj
+++ b/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.Web/Dressca.UnitTests.Web.csproj
@@ -1,8 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.Web/Dressca.UnitTests.Web.csproj
+++ b/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.Web/Dressca.UnitTests.Web.csproj
@@ -13,16 +13,13 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
     <PackageReference Include="StyleCop.Analyzers">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.Web/Runtime/BusinessExceptionDevelopmentFilterTest.cs
+++ b/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.Web/Runtime/BusinessExceptionDevelopmentFilterTest.cs
@@ -8,7 +8,6 @@ using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Logging;
-using Xunit.Abstractions;
 
 namespace Dressca.UnitTests.Web.Runtime;
 

--- a/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.Web/Runtime/BusinessExceptionFilterTest.cs
+++ b/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.Web/Runtime/BusinessExceptionFilterTest.cs
@@ -8,7 +8,6 @@ using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Logging;
-using Xunit.Abstractions;
 
 namespace Dressca.UnitTests.Web.Runtime;
 

--- a/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.Web/Runtime/DbUpdateConcurrencyExceptionDevelopmentFilterTest.cs
+++ b/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.Web/Runtime/DbUpdateConcurrencyExceptionDevelopmentFilterTest.cs
@@ -8,7 +8,6 @@ using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
-using Xunit.Abstractions;
 
 namespace Dressca.UnitTests.Web.Runtime;
 

--- a/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.Web/Runtime/DbUpdateConcurrencyExceptionFilterTest.cs
+++ b/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.Web/Runtime/DbUpdateConcurrencyExceptionFilterTest.cs
@@ -8,7 +8,6 @@ using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
-using Xunit.Abstractions;
 
 namespace Dressca.UnitTests.Web.Runtime;
 

--- a/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.Web/TestBase.cs
+++ b/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.Web/TestBase.cs
@@ -1,7 +1,6 @@
 ﻿using Maris.Logging.Testing.Xunit;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Testing;
-using Xunit.Abstractions;
 
 namespace Dressca.UnitTests.Web;
 

--- a/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.Web/xunit.runner.json
+++ b/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.Web/xunit.runner.json
@@ -1,0 +1,3 @@
+﻿{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json"
+}

--- a/samples/Dressca/dressca-backend/tests/Dressca.Web.Admin.IntegrationTest/DatabaseHealthCheckTest.cs
+++ b/samples/Dressca/dressca-backend/tests/Dressca.Web.Admin.IntegrationTest/DatabaseHealthCheckTest.cs
@@ -12,13 +12,14 @@ public class DatabaseHealthCheckTest(IntegrationTestWebApplicationFactory<Progra
     {
         // Arrange
         var client = this.factory.CreateClient();
+        var cancellationToken = TestContext.Current.CancellationToken;
 
         // Act
-        var response = await client.GetAsync("api/health");
+        var response = await client.GetAsync("api/health", cancellationToken);
 
         // Assert
         response.EnsureSuccessStatusCode();
-        var healthCheckResult = await response.Content.ReadAsStringAsync();
+        var healthCheckResult = await response.Content.ReadAsStringAsync(cancellationToken);
         Assert.Equal("Healthy", healthCheckResult);
     }
 }

--- a/samples/Dressca/dressca-backend/tests/Dressca.Web.Admin.IntegrationTest/DatabaseHealthCheckTest.cs
+++ b/samples/Dressca/dressca-backend/tests/Dressca.Web.Admin.IntegrationTest/DatabaseHealthCheckTest.cs
@@ -1,6 +1,4 @@
-﻿using Xunit;
-
-namespace Dressca.Web.Admin.IntegrationTest;
+﻿namespace Dressca.Web.Admin.IntegrationTest;
 
 public class DatabaseHealthCheckTest(IntegrationTestWebApplicationFactory<Program> factory)
     : IClassFixture<IntegrationTestWebApplicationFactory<Program>>

--- a/samples/Dressca/dressca-backend/tests/Dressca.Web.Admin.IntegrationTest/Dressca.Web.Admin.IntegrationTest.csproj
+++ b/samples/Dressca/dressca-backend/tests/Dressca.Web.Admin.IntegrationTest/Dressca.Web.Admin.IntegrationTest.csproj
@@ -1,11 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <Content Include="appsettings.IntegrationTest.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
+    <Content Include="appsettings.IntegrationTest.json" CopyToPublishDirectory="PreserveNewest" />
+    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />

--- a/samples/Dressca/dressca-backend/tests/Dressca.Web.Admin.IntegrationTest/Dressca.Web.Admin.IntegrationTest.csproj
+++ b/samples/Dressca/dressca-backend/tests/Dressca.Web.Admin.IntegrationTest/Dressca.Web.Admin.IntegrationTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <Content Include="appsettings.IntegrationTest.json" CopyToPublishDirectory="PreserveNewest" />
+    <Content Include="appsettings.IntegrationTest.json" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 

--- a/samples/Dressca/dressca-backend/tests/Dressca.Web.Admin.IntegrationTest/Dressca.Web.Admin.IntegrationTest.csproj
+++ b/samples/Dressca/dressca-backend/tests/Dressca.Web.Admin.IntegrationTest/Dressca.Web.Admin.IntegrationTest.csproj
@@ -19,7 +19,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/samples/Dressca/dressca-backend/tests/Dressca.Web.Admin.IntegrationTest/Dressca.Web.Admin.IntegrationTest.csproj
+++ b/samples/Dressca/dressca-backend/tests/Dressca.Web.Admin.IntegrationTest/Dressca.Web.Admin.IntegrationTest.csproj
@@ -1,12 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <IsPackable>false</IsPackable>
-    <IsTestProject>true</IsTestProject>
-    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
-    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
-  </PropertyGroup>
-
   <ItemGroup>
     <Content Include="appsettings.IntegrationTest.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/samples/Dressca/dressca-backend/tests/Dressca.Web.Admin.IntegrationTest/Dressca.Web.Admin.IntegrationTest.csproj
+++ b/samples/Dressca/dressca-backend/tests/Dressca.Web.Admin.IntegrationTest/Dressca.Web.Admin.IntegrationTest.csproj
@@ -17,16 +17,13 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
     <PackageReference Include="StyleCop.Analyzers">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/samples/Dressca/dressca-backend/tests/Dressca.Web.Admin.IntegrationTest/Dressca.Web.Admin.IntegrationTest.csproj
+++ b/samples/Dressca/dressca-backend/tests/Dressca.Web.Admin.IntegrationTest/Dressca.Web.Admin.IntegrationTest.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Dressca/dressca-backend/tests/Dressca.Web.Admin.IntegrationTest/xunit.runner.json
+++ b/samples/Dressca/dressca-backend/tests/Dressca.Web.Admin.IntegrationTest/xunit.runner.json
@@ -1,0 +1,3 @@
+﻿{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json"
+}

--- a/samples/Dressca/dressca-backend/tests/Maris.Logging.Testing.Tests/Maris.Logging.Testing.Tests.csproj
+++ b/samples/Dressca/dressca-backend/tests/Maris.Logging.Testing.Tests/Maris.Logging.Testing.Tests.csproj
@@ -1,6 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
+    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+  
+  <ItemGroup>
     <Using Include="Moq" />
   </ItemGroup>
 

--- a/samples/Dressca/dressca-backend/tests/Maris.Logging.Testing.Tests/Maris.Logging.Testing.Tests.csproj
+++ b/samples/Dressca/dressca-backend/tests/Maris.Logging.Testing.Tests/Maris.Logging.Testing.Tests.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <Using Include="Xunit" />
     <Using Include="Moq" />
   </ItemGroup>
 

--- a/samples/Dressca/dressca-backend/tests/Maris.Logging.Testing.Tests/Maris.Logging.Testing.Tests.csproj
+++ b/samples/Dressca/dressca-backend/tests/Maris.Logging.Testing.Tests/Maris.Logging.Testing.Tests.csproj
@@ -1,12 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <IsPackable>false</IsPackable>
-    <IsTestProject>true</IsTestProject>
-    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
-    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
-  </PropertyGroup>
-
   <ItemGroup>
     <Using Include="Xunit" />
     <Using Include="Moq" />

--- a/samples/Dressca/dressca-backend/tests/Maris.Logging.Testing.Tests/Maris.Logging.Testing.Tests.csproj
+++ b/samples/Dressca/dressca-backend/tests/Maris.Logging.Testing.Tests/Maris.Logging.Testing.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
     <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
     <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
   </PropertyGroup>

--- a/samples/Dressca/dressca-backend/tests/Maris.Logging.Testing.Tests/Maris.Logging.Testing.Tests.csproj
+++ b/samples/Dressca/dressca-backend/tests/Maris.Logging.Testing.Tests/Maris.Logging.Testing.Tests.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Dressca/dressca-backend/tests/Maris.Logging.Testing.Tests/Maris.Logging.Testing.Tests.csproj
+++ b/samples/Dressca/dressca-backend/tests/Maris.Logging.Testing.Tests/Maris.Logging.Testing.Tests.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
     <PackageReference Include="Moq" />
     <PackageReference Include="StyleCop.Analyzers">
       <PrivateAssets>all</PrivateAssets>
@@ -20,10 +21,6 @@
     </PackageReference>
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/samples/Dressca/dressca-backend/tests/Maris.Logging.Testing.Tests/Maris.Logging.Testing.Tests.csproj
+++ b/samples/Dressca/dressca-backend/tests/Maris.Logging.Testing.Tests/Maris.Logging.Testing.Tests.csproj
@@ -16,7 +16,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/samples/Dressca/dressca-backend/tests/Maris.Logging.Testing.Tests/Xunit/FakeLoggingBuilderExtensionsTest.cs
+++ b/samples/Dressca/dressca-backend/tests/Maris.Logging.Testing.Tests/Xunit/FakeLoggingBuilderExtensionsTest.cs
@@ -2,7 +2,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Testing;
-using Xunit.Abstractions;
 
 namespace Maris.Logging.Testing.Tests.Xunit;
 

--- a/samples/Dressca/dressca-backend/tests/Maris.Logging.Testing.Tests/Xunit/TestLoggerManagerTest.cs
+++ b/samples/Dressca/dressca-backend/tests/Maris.Logging.Testing.Tests/Xunit/TestLoggerManagerTest.cs
@@ -1,6 +1,5 @@
 ﻿using Maris.Logging.Testing.Xunit;
 using Microsoft.Extensions.Logging;
-using Xunit.Abstractions;
 
 namespace Maris.Logging.Testing.Tests.Xunit;
 

--- a/samples/Dressca/dressca-backend/tests/Maris.Logging.Testing.Tests/Xunit/TestLoggerServiceCollectionExtensionsTest.cs
+++ b/samples/Dressca/dressca-backend/tests/Maris.Logging.Testing.Tests/Xunit/TestLoggerServiceCollectionExtensionsTest.cs
@@ -2,7 +2,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Testing;
-using Xunit.Abstractions;
 
 namespace Maris.Logging.Testing.Tests.Xunit;
 

--- a/samples/Dressca/dressca-backend/tests/Maris.Logging.Testing.Tests/Xunit/XunitLoggerProviderTest.cs
+++ b/samples/Dressca/dressca-backend/tests/Maris.Logging.Testing.Tests/Xunit/XunitLoggerProviderTest.cs
@@ -1,6 +1,5 @@
 ﻿using System.Reflection;
 using Maris.Logging.Testing.Xunit;
-using Xunit.Abstractions;
 
 namespace Maris.Logging.Testing.Tests.Xunit;
 

--- a/samples/Dressca/dressca-backend/tests/Maris.Logging.Testing.Tests/Xunit/XunitLoggerTest.cs
+++ b/samples/Dressca/dressca-backend/tests/Maris.Logging.Testing.Tests/Xunit/XunitLoggerTest.cs
@@ -1,6 +1,5 @@
 ﻿using Maris.Logging.Testing.Xunit;
 using Microsoft.Extensions.Logging;
-using Xunit.Abstractions;
 
 namespace Maris.Logging.Testing.Tests.Xunit;
 

--- a/samples/Dressca/dressca-backend/tests/Maris.Logging.Testing.Tests/Xunit/XunitLoggingBuilderExtensionsTest.cs
+++ b/samples/Dressca/dressca-backend/tests/Maris.Logging.Testing.Tests/Xunit/XunitLoggingBuilderExtensionsTest.cs
@@ -1,7 +1,6 @@
 ﻿using Maris.Logging.Testing.Xunit;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Xunit.Abstractions;
 
 namespace Maris.Logging.Testing.Tests.Xunit;
 

--- a/samples/Dressca/dressca-backend/tests/Maris.Logging.Testing.Tests/xunit.runner.json
+++ b/samples/Dressca/dressca-backend/tests/Maris.Logging.Testing.Tests/xunit.runner.json
@@ -1,0 +1,3 @@
+﻿{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json"
+}


### PR DESCRIPTION
## この Pull request で実施したこと

Dressca(Admin, Consumer)のテスティングフレームワークを [xunit.v3](https://xunit.net/docs/getting-started/v3/whats-new) に更新しました。
それに伴い、以下の変更を行いました。

- カバレッジ取得ツールの変更( `coverlet.collector` > `Microsoft.Testing.Extensions.CodeCoverage` )
- [Xunit.v3 のプロジェクトテンプレート](https://xunit.net/docs/getting-started/v3/cmdline) への更新（一部は Directory.Build.props に設定してあります）
- Xunit の破壊的変更への対応
- テストが 1 つもないテストプロジェクトへのダミーテストファイルの追加（テストが 1 つもないとエラー扱いされるため）
- CI ワークフローのテスト実行コマンドを変更（<https://xunit.net/docs/getting-started/v3/microsoft-testing-platform>）
- xUnit の設定ファイルをプロジェクトテンプレートに従って追加しました（設定ファイルは空）。

## この Pull request では実施していないこと

Azure AD B2C サンプル、ConsoleAppWithDI サンプルは修正していません。

## Issues や Discussions 、関連する Web サイトなどへのリンク

- <https://devblogs.microsoft.com/dotnet/mtp-adoption-frameworks/#xunit.net>
- <https://xunit.net/docs/getting-started/v3/cmdline>
- <https://xunit.net/docs/getting-started/v3/whats-new>
- <https://xunit.net/docs/getting-started/v3/microsoft-testing-platform>