### PR TITLE
ConsoleAppWithDIをxunit-v3へ更新する

### DIFF
--- a/.github/workflows/samples-console-app-with-di.ci.yml
+++ b/.github/workflows/samples-console-app-with-di.ci.yml
@@ -26,7 +26,6 @@ jobs:
       DOTNET_NOLOGO: true
       DOTNET_CLI_TELEMETRY_OPTOUT: true
       BUILD_CONFIGURATION: Debug
-      BUILD_SUMMARY_FILE: BuildSummary.md
     permissions:
       checks: write
       contents: read

--- a/.github/workflows/samples-console-app-with-di.ci.yml
+++ b/.github/workflows/samples-console-app-with-di.ci.yml
@@ -65,9 +65,11 @@ jobs:
           exit 1
 
       - id: run-tests
-        name: テストの実行
+        name: 単体テストの実行
         continue-on-error: true
-        run: dotnet test --no-build --logger trx --verbosity normal --configuration ${{ env.BUILD_CONFIGURATION }} --collect "XPlat Code Coverage"
+        run: |
+          echo '## Test Result :memo:' >> $GITHUB_STEP_SUMMARY
+          dotnet test --no-build --nologo --verbosity normal --configuration ${{ env.BUILD_CONFIGURATION }} -- --coverage --coverage-output-format cobertura --coverage-output coverage.cobertura.xml --report-xunit-trx
 
       - id: create-test-result-report
         name: テスト結果ページの作成

--- a/.github/workflows/samples-console-app-with-di.ci.yml
+++ b/.github/workflows/samples-console-app-with-di.ci.yml
@@ -52,7 +52,7 @@ jobs:
           echo '```' >> $GITHUB_STEP_SUMMARY
           cat build-result.txt >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
-    
+
       - name: ビルド失敗時の結果表示
         shell: bash
         if: ${{ steps.application-build.outcome == 'failure' }}
@@ -89,7 +89,7 @@ jobs:
 
       - id: create-coverage-report
         name: コードカバレッジレポートの解析と作成
-        uses: danielpalme/ReportGenerator-GitHub-Action@f1927db1dbfc029b056583ee488832e939447fe6 # v5.4.4
+        uses: danielpalme/ReportGenerator-GitHub-Action@f1927db1dbfc029b056583ee488832e939447fe6  # v5.4.4
         if: ${{ success() || (failure() && steps.run-tests.conclusion == 'failure') }}
         with:
           reports: '**/TestResults/coverage.cobertura.xml'

--- a/.github/workflows/samples-console-app-with-di.ci.yml
+++ b/.github/workflows/samples-console-app-with-di.ci.yml
@@ -73,27 +73,20 @@ jobs:
 
       - id: create-test-result-report
         name: テスト結果ページの作成
-        uses: dorny/test-reporter@6e6a65b7a0bd2c9197df7d0ae36ac5cee784230c  # v2.0.0
-        if: ${{ success() || (failure() && steps.run-tests.conclusion == 'failure') }}
+        uses: dorny/test-reporter@v2
         with:
           name: 'Test results'
           path: '**/TestResults/*.trx'
           path-replace-backslashes: 'true'
           reporter: 'dotnet-trx'
           only-summary: 'false'
-          list-suites: 'all'
-          list-tests: 'all'
+          use-actions-summary: 'true'
+          badge-title: 'tests'
+          list-suites: 'failed'
+          list-tests: 'failed'
           max-annotations: '10'
-          fail-on-error: 'true'
-
-      - name: テスト結果のサマリー表示
-        shell: bash
-        if: ${{ success() || (failure() && steps.run-tests.conclusion == 'failure') }}
-        run: |
-          echo '## Test Result :memo:' >> ${{ env.BUILD_SUMMARY_FILE }}
-          echo 'Test was a **${{ steps.create-test-result-report.outputs.conclusion }}**.' >> ${{ env.BUILD_SUMMARY_FILE }}
-          echo 'Completed in ${{ steps.create-test-result-report.outputs.time }}ms with **${{ steps.create-test-result-report.outputs.passed }}** passed, **${{ steps.create-test-result-report.outputs.failed }}** failed and ${{ steps.create-test-result-report.outputs.skipped }} skipped.' >> ${{ env.BUILD_SUMMARY_FILE }}
-          cat ${{ env.BUILD_SUMMARY_FILE }} >> $GITHUB_STEP_SUMMARY
+          fail-on-error: 'false'
+          fail-on-empty: 'true'
 
       - id: create-coverage-report
         name: コードカバレッジレポートの解析と作成

--- a/.github/workflows/samples-console-app-with-di.ci.yml
+++ b/.github/workflows/samples-console-app-with-di.ci.yml
@@ -42,16 +42,27 @@ jobs:
         with:
           dotnet-version: "8.*"
 
-      - id: application-build
-        name: アプリケーションのビルド
-        run: dotnet build --configuration ${{ env.BUILD_CONFIGURATION }} --verbosity minimal > build-result.txt
-
-      - name: ビルド結果の表示
+      - name: アプリケーションのビルド
+        id: application-build
         shell: bash
-        if: ${{ success() || (failure() && steps.application-build.conclusion == 'failure') }}
+        continue-on-error: true
         run: |
           echo '## Build Result :gear:' >> $GITHUB_STEP_SUMMARY
-          cat build-result.txt | sed -n -e 's/^/> /p' >> $GITHUB_STEP_SUMMARY
+          dotnet build --nologo --configuration ${{ env.BUILD_CONFIGURATION }} --verbosity minimal > build-result.txt
+          echo ':heavy_check_mark: アプリケーションのビルドに成功しました。' >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          cat build-result.txt >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+    
+      - name: ビルド失敗時の結果表示
+        shell: bash
+        if: ${{ steps.application-build.outcome == 'failure' }}
+        run: |
+          echo ':x: アプリケーションのビルドに失敗しました。  ' >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          cat build-result.txt >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          exit 1
 
       - id: run-tests
         name: テストの実行

--- a/.github/workflows/samples-console-app-with-di.ci.yml
+++ b/.github/workflows/samples-console-app-with-di.ci.yml
@@ -92,7 +92,7 @@ jobs:
         uses: danielpalme/ReportGenerator-GitHub-Action@f1927db1dbfc029b056583ee488832e939447fe6 # v5.4.4
         if: ${{ success() || (failure() && steps.run-tests.conclusion == 'failure') }}
         with:
-          reports: '**/TestResults/*/coverage.cobertura.xml'
+          reports: '**/TestResults/coverage.cobertura.xml'
           targetdir: '${{ env.WORKING_DIRECTORY }}/CoverageReport'
           reporttypes: 'MarkdownSummaryGithub'
 

--- a/.github/workflows/samples-console-app-with-di.ci.yml
+++ b/.github/workflows/samples-console-app-with-di.ci.yml
@@ -104,3 +104,7 @@ jobs:
           sed -i s/'# Summary'/'## Coverage :triangular_ruler:'/g CoverageReport/SummaryGithub.md
           sed -i -e '/^## Coverage$/d' CoverageReport/SummaryGithub.md
           cat CoverageReport/SummaryGithub.md >> $GITHUB_STEP_SUMMARY
+
+      - name: 単体テスト結果の確認
+        if: ${{ steps.create-test-result-report.outputs.conclusion == 'failure' }}
+        run: exit 1

--- a/.github/workflows/samples-console-app-with-di.ci.yml
+++ b/.github/workflows/samples-console-app-with-di.ci.yml
@@ -89,7 +89,7 @@ jobs:
 
       - id: create-coverage-report
         name: コードカバレッジレポートの解析と作成
-        uses: danielpalme/ReportGenerator-GitHub-Action@f1927db1dbfc029b056583ee488832e939447fe6  # v5.4.4
+        uses: danielpalme/ReportGenerator-GitHub-Action@f1927db1dbfc029b056583ee488832e939447fe6 # v5.4.4
         if: ${{ success() || (failure() && steps.run-tests.conclusion == 'failure') }}
         with:
           reports: '**/TestResults/*/coverage.cobertura.xml'

--- a/.github/workflows/samples-console-app-with-di.ci.yml
+++ b/.github/workflows/samples-console-app-with-di.ci.yml
@@ -30,7 +30,6 @@ jobs:
     permissions:
       checks: write
       contents: read
-      pull-requests: write
 
     steps:
       - name: ブランチのチェックアウト
@@ -99,11 +98,3 @@ jobs:
           sed -i s/'# Summary'/'## Coverage :triangular_ruler:'/g CoverageReport/SummaryGithub.md
           sed -i -e '/^## Coverage$/d' CoverageReport/SummaryGithub.md
           cat CoverageReport/SummaryGithub.md >> $GITHUB_STEP_SUMMARY
-          cat CoverageReport/SummaryGithub.md >> ${{ env.BUILD_SUMMARY_FILE }}
-
-      - name: ビルドサマリーをPull-requestに表示
-        uses: marocchino/sticky-pull-request-comment@52423e01640425a022ef5fd42c6fb5f633a02728  # v2.9.1
-        if: ${{ github.event_name == 'pull_request' && (success() || (failure() && steps.run-tests.conclusion == 'failure')) }}
-        with:
-          recreate: true
-          path: '${{ env.WORKING_DIRECTORY }}/${{ env.BUILD_SUMMARY_FILE }}'

--- a/samples/ConsoleAppWithDI/solution/Directory.Packages.props
+++ b/samples/ConsoleAppWithDI/solution/Directory.Packages.props
@@ -1,7 +1,6 @@
 ﻿<Project>
   <ItemGroup>
     <PackageVersion Include="CommandLineParser" Version="2.9.1" />
-    <PackageVersion Include="coverlet.collector" Version="6.0.3" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.Testing" Version="8.10.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1" />
@@ -9,6 +8,7 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="8.10.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.14.2" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.1" />

--- a/samples/ConsoleAppWithDI/solution/Directory.Packages.props
+++ b/samples/ConsoleAppWithDI/solution/Directory.Packages.props
@@ -1,4 +1,4 @@
-<Project>
+﻿<Project>
   <ItemGroup>
     <PackageVersion Include="CommandLineParser" Version="2.9.1" />
     <PackageVersion Include="coverlet.collector" Version="6.0.3" />
@@ -11,8 +11,8 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
-    <PackageVersion Include="xunit" Version="2.9.3" />
-    <PackageVersion Include="xunit.abstractions" Version="2.0.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.1" />
+    <PackageVersion Include="xunit.v3" Version="2.0.0" />
+    <PackageVersion Include="xunit.v3.extensibility.core" Version="2.0.0" />
   </ItemGroup>
 </Project>

--- a/samples/ConsoleAppWithDI/solution/src/Maris.ConsoleApp.Hosting/ConsoleAppHostedService.cs
+++ b/samples/ConsoleAppWithDI/solution/src/Maris.ConsoleApp.Hosting/ConsoleAppHostedService.cs
@@ -16,6 +16,7 @@ internal class ConsoleAppHostedService : IHostedService
     private readonly ILogger logger;
     private readonly TimeProvider timeProvider;
     private long startTime;
+    private int exitCode;
 
     /// <summary>
     ///  <see cref="ConsoleAppHostedService"/> クラスの新しいインスタンスを初期化します。
@@ -82,17 +83,17 @@ internal class ConsoleAppHostedService : IHostedService
         try
         {
             var returnCode = await this.executor.ExecuteCommandAsync(cancellationToken);
-            this.SetExitCode(returnCode);
+            this.InternalSetExitCode(returnCode);
         }
         catch (InvalidParameterException ex)
         {
             this.logger.LogError(Events.InvalidParameterDetected, ex, LogMessages.CommandExecutorRaiseException, this.executor.CommandName);
-            this.SetExitCode(this.settings.DefaultValidationErrorExitCode);
+            this.InternalSetExitCode(this.settings.DefaultValidationErrorExitCode);
         }
         catch (Exception ex)
         {
             this.logger.LogError(Events.CommandExecutorRaiseException, ex, LogMessages.CommandExecutorRaiseException, this.executor.CommandName);
-            this.SetExitCode(this.settings.DefaultErrorExitCode);
+            this.InternalSetExitCode(this.settings.DefaultErrorExitCode);
         }
         finally
         {
@@ -112,8 +113,14 @@ internal class ConsoleAppHostedService : IHostedService
             Events.StopHostingService,
             LogMessages.StopHostingService,
             this.executor.CommandName,
-            Environment.ExitCode,
+            this.exitCode,
             this.timeProvider.GetElapsedTime(this.startTime).TotalMilliseconds);
         return Task.CompletedTask;
+    }
+
+    private void InternalSetExitCode(int exitCode)
+    {
+        this.exitCode = exitCode;
+        this.SetExitCode(exitCode);
     }
 }

--- a/samples/ConsoleAppWithDI/solution/src/Maris.Logging.Testing/Maris.Logging.Testing.csproj
+++ b/samples/ConsoleAppWithDI/solution/src/Maris.Logging.Testing/Maris.Logging.Testing.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" />
@@ -7,7 +7,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit.abstractions" />
+    <PackageReference Include="xunit.v3.extensibility.core" />
   </ItemGroup>
 
 </Project>

--- a/samples/ConsoleAppWithDI/solution/src/Maris.Logging.Testing/Xunit/TestLoggerManager.cs
+++ b/samples/ConsoleAppWithDI/solution/src/Maris.Logging.Testing/Xunit/TestLoggerManager.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Testing;
-using Xunit.Abstractions;
+using Xunit;
 
 namespace Maris.Logging.Testing.Xunit;
 

--- a/samples/ConsoleAppWithDI/solution/src/Maris.Logging.Testing/Xunit/XunitLogger.cs
+++ b/samples/ConsoleAppWithDI/solution/src/Maris.Logging.Testing/Xunit/XunitLogger.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.Extensions.Logging;
-using Xunit.Abstractions;
+using Xunit;
 
 namespace Maris.Logging.Testing.Xunit;
 

--- a/samples/ConsoleAppWithDI/solution/src/Maris.Logging.Testing/Xunit/XunitLoggerProvider.cs
+++ b/samples/ConsoleAppWithDI/solution/src/Maris.Logging.Testing/Xunit/XunitLoggerProvider.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.Extensions.Logging;
-using Xunit.Abstractions;
+using Xunit;
 
 namespace Maris.Logging.Testing.Xunit;
 

--- a/samples/ConsoleAppWithDI/solution/tests/Directory.Build.props
+++ b/samples/ConsoleAppWithDI/solution/tests/Directory.Build.props
@@ -4,6 +4,9 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/ConsoleAppWithDI/solution/tests/Maris.ConsoleApp.IntegrationTests/Maris.ConsoleApp.IntegrationTests.csproj
+++ b/samples/ConsoleAppWithDI/solution/tests/Maris.ConsoleApp.IntegrationTests/Maris.ConsoleApp.IntegrationTests.csproj
@@ -4,16 +4,13 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
     <PackageReference Include="StyleCop.Analyzers">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/samples/ConsoleAppWithDI/solution/tests/Maris.ConsoleApp.IntegrationTests/Maris.ConsoleApp.IntegrationTests.csproj
+++ b/samples/ConsoleAppWithDI/solution/tests/Maris.ConsoleApp.IntegrationTests/Maris.ConsoleApp.IntegrationTests.csproj
@@ -8,7 +8,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/samples/ConsoleAppWithDI/solution/tests/Maris.ConsoleApp.IntegrationTests/ScopeTests/Condition.cs
+++ b/samples/ConsoleAppWithDI/solution/tests/Maris.ConsoleApp.IntegrationTests/ScopeTests/Condition.cs
@@ -1,6 +1,6 @@
 ﻿namespace Maris.ConsoleApp.IntegrationTests.ScopeTests;
 
-internal enum Condition : inta
+internal enum Condition : int
 {
     Unknown = 0,
     Creating = 1,

--- a/samples/ConsoleAppWithDI/solution/tests/Maris.ConsoleApp.IntegrationTests/ScopeTests/Condition.cs
+++ b/samples/ConsoleAppWithDI/solution/tests/Maris.ConsoleApp.IntegrationTests/ScopeTests/Condition.cs
@@ -1,6 +1,6 @@
 ﻿namespace Maris.ConsoleApp.IntegrationTests.ScopeTests;
 
-internal enum Condition : int
+internal enum Condition : inta
 {
     Unknown = 0,
     Creating = 1,

--- a/samples/ConsoleAppWithDI/solution/tests/Maris.ConsoleApp.IntegrationTests/ScopeTests/ObjectState.cs
+++ b/samples/ConsoleAppWithDI/solution/tests/Maris.ConsoleApp.IntegrationTests/ScopeTests/ObjectState.cs
@@ -3,7 +3,7 @@
 internal class ObjectState
 {
     private readonly TimeProvider timeProvider;
-    private DateTime createDate;
+    private readonly DateTime createDate;
 
     internal ObjectState(Guid objectId, Type objectType, Condition condition, TimeProvider timeProvider)
     {

--- a/samples/ConsoleAppWithDI/solution/tests/Maris.ConsoleApp.IntegrationTests/ScopeTests/ScopedTest.cs
+++ b/samples/ConsoleAppWithDI/solution/tests/Maris.ConsoleApp.IntegrationTests/ScopeTests/ScopedTest.cs
@@ -14,9 +14,10 @@ public class ScopedTest(ITestOutputHelper testOutputHelper) : TestBase(testOutpu
         // Arrange
         ObjectStateHistory.Clear();
         using var app = this.CreateHost();
+        var cancellationToken = TestContext.Current.CancellationToken;
 
         // Act
-        await app.RunAsync();
+        await app.RunAsync(cancellationToken);
 
         // Assert
         var createHistories = ObjectStateHistory.Histories
@@ -35,9 +36,10 @@ public class ScopedTest(ITestOutputHelper testOutputHelper) : TestBase(testOutpu
         // Arrange
         ObjectStateHistory.Clear();
         using var app = this.CreateHost();
+        var cancellationToken = TestContext.Current.CancellationToken;
 
         // Act
-        await app.RunAsync();
+        await app.RunAsync(cancellationToken);
 
         // Assert
         var createHistories = ObjectStateHistory.Histories
@@ -57,9 +59,10 @@ public class ScopedTest(ITestOutputHelper testOutputHelper) : TestBase(testOutpu
         // Arrange
         ObjectStateHistory.Clear();
         using var app = this.CreateHost();
+        var cancellationToken = TestContext.Current.CancellationToken;
 
         // Act
-        await app.RunAsync();
+        await app.RunAsync(cancellationToken);
 
         // Assert
         var createHistories = ObjectStateHistory.Histories
@@ -78,9 +81,10 @@ public class ScopedTest(ITestOutputHelper testOutputHelper) : TestBase(testOutpu
         // Arrange
         ObjectStateHistory.Clear();
         using var app = this.CreateHost();
+        var cancellationToken = TestContext.Current.CancellationToken;
 
         // Act
-        await app.RunAsync();
+        await app.RunAsync(cancellationToken);
 
         // Assert
         var createHistories = ObjectStateHistory.Histories
@@ -99,9 +103,10 @@ public class ScopedTest(ITestOutputHelper testOutputHelper) : TestBase(testOutpu
         // Arrange
         ObjectStateHistory.Clear();
         using var app = this.CreateHost();
+        var cancellationToken = TestContext.Current.CancellationToken;
 
         // Act
-        await app.RunAsync();
+        await app.RunAsync(cancellationToken);
 
         // Assert
         var createHistories = ObjectStateHistory.Histories

--- a/samples/ConsoleAppWithDI/solution/tests/Maris.ConsoleApp.IntegrationTests/ScopeTests/ScopedTest.cs
+++ b/samples/ConsoleAppWithDI/solution/tests/Maris.ConsoleApp.IntegrationTests/ScopeTests/ScopedTest.cs
@@ -2,7 +2,6 @@
 using Maris.ConsoleApp.IntegrationTests.ScopeTests.Commands;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Xunit.Abstractions;
 
 namespace Maris.ConsoleApp.IntegrationTests.ScopeTests;
 

--- a/samples/ConsoleAppWithDI/solution/tests/Maris.ConsoleApp.IntegrationTests/ScopeTests/SingletonTest.cs
+++ b/samples/ConsoleAppWithDI/solution/tests/Maris.ConsoleApp.IntegrationTests/ScopeTests/SingletonTest.cs
@@ -14,9 +14,10 @@ public class SingletonTest(ITestOutputHelper testOutputHelper) : TestBase(testOu
         // Arrange
         ObjectStateHistory.Clear();
         using var app = this.CreateHost();
+        var cancellationToken = TestContext.Current.CancellationToken;
 
         // Act
-        await app.RunAsync();
+        await app.RunAsync(cancellationToken);
 
         // Assert
         var createHistories = ObjectStateHistory.Histories
@@ -35,9 +36,10 @@ public class SingletonTest(ITestOutputHelper testOutputHelper) : TestBase(testOu
         // Arrange
         ObjectStateHistory.Clear();
         using var app = this.CreateHost();
+        var cancellationToken = TestContext.Current.CancellationToken;
 
         // Act
-        await app.RunAsync();
+        await app.RunAsync(cancellationToken);
 
         // Assert
         var createHistories = ObjectStateHistory.Histories
@@ -57,9 +59,10 @@ public class SingletonTest(ITestOutputHelper testOutputHelper) : TestBase(testOu
         // Arrange
         ObjectStateHistory.Clear();
         using var app = this.CreateHost();
+        var cancellationToken = TestContext.Current.CancellationToken;
 
         // Act
-        await app.RunAsync();
+        await app.RunAsync(cancellationToken);
 
         // Assert
         var createHistories = ObjectStateHistory.Histories
@@ -78,9 +81,10 @@ public class SingletonTest(ITestOutputHelper testOutputHelper) : TestBase(testOu
         // Arrange
         ObjectStateHistory.Clear();
         using var app = this.CreateHost();
+        var cancellationToken = TestContext.Current.CancellationToken;
 
         // Act
-        await app.RunAsync();
+        await app.RunAsync(cancellationToken);
 
         // Assert
         var createHistories = ObjectStateHistory.Histories
@@ -99,9 +103,10 @@ public class SingletonTest(ITestOutputHelper testOutputHelper) : TestBase(testOu
         // Arrange
         ObjectStateHistory.Clear();
         using var app = this.CreateHost();
+        var cancellationToken = TestContext.Current.CancellationToken;
 
         // Act
-        await app.RunAsync();
+        await app.RunAsync(cancellationToken);
 
         // Assert
         var createHistories = ObjectStateHistory.Histories

--- a/samples/ConsoleAppWithDI/solution/tests/Maris.ConsoleApp.IntegrationTests/ScopeTests/SingletonTest.cs
+++ b/samples/ConsoleAppWithDI/solution/tests/Maris.ConsoleApp.IntegrationTests/ScopeTests/SingletonTest.cs
@@ -2,7 +2,6 @@
 using Maris.ConsoleApp.IntegrationTests.ScopeTests.Commands;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Xunit.Abstractions;
 
 namespace Maris.ConsoleApp.IntegrationTests.ScopeTests;
 

--- a/samples/ConsoleAppWithDI/solution/tests/Maris.ConsoleApp.IntegrationTests/ScopeTests/TransientTest.cs
+++ b/samples/ConsoleAppWithDI/solution/tests/Maris.ConsoleApp.IntegrationTests/ScopeTests/TransientTest.cs
@@ -2,7 +2,6 @@
 using Maris.ConsoleApp.IntegrationTests.ScopeTests.Commands;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Xunit.Abstractions;
 
 namespace Maris.ConsoleApp.IntegrationTests.ScopeTests;
 

--- a/samples/ConsoleAppWithDI/solution/tests/Maris.ConsoleApp.IntegrationTests/ScopeTests/TransientTest.cs
+++ b/samples/ConsoleAppWithDI/solution/tests/Maris.ConsoleApp.IntegrationTests/ScopeTests/TransientTest.cs
@@ -14,9 +14,10 @@ public class TransientTest(ITestOutputHelper testOutputHelper) : TestBase(testOu
         // Arrange
         ObjectStateHistory.Clear();
         using var app = this.CreateHost();
+        var cancellationToken = TestContext.Current.CancellationToken;
 
         // Act
-        await app.RunAsync();
+        await app.RunAsync(cancellationToken);
 
         // Assert
         var createHistories = ObjectStateHistory.Histories
@@ -36,9 +37,10 @@ public class TransientTest(ITestOutputHelper testOutputHelper) : TestBase(testOu
         // Arrange
         ObjectStateHistory.Clear();
         using var app = this.CreateHost();
+        var cancellationToken = TestContext.Current.CancellationToken;
 
         // Act
-        await app.RunAsync();
+        await app.RunAsync(cancellationToken);
 
         // Assert
         var createHistories = ObjectStateHistory.Histories
@@ -58,9 +60,10 @@ public class TransientTest(ITestOutputHelper testOutputHelper) : TestBase(testOu
         // Arrange
         ObjectStateHistory.Clear();
         using var app = this.CreateHost();
+        var cancellationToken = TestContext.Current.CancellationToken;
 
         // Act
-        await app.RunAsync();
+        await app.RunAsync(cancellationToken);
 
         // Assert
         var createHistories = ObjectStateHistory.Histories
@@ -80,9 +83,10 @@ public class TransientTest(ITestOutputHelper testOutputHelper) : TestBase(testOu
         // Arrange
         ObjectStateHistory.Clear();
         using var app = this.CreateHost();
+        var cancellationToken = TestContext.Current.CancellationToken;
 
         // Act
-        await app.RunAsync();
+        await app.RunAsync(cancellationToken);
 
         // Assert
         var createHistories = ObjectStateHistory.Histories
@@ -102,9 +106,10 @@ public class TransientTest(ITestOutputHelper testOutputHelper) : TestBase(testOu
         // Arrange
         ObjectStateHistory.Clear();
         using var app = this.CreateHost();
+        var cancellationToken = TestContext.Current.CancellationToken;
 
         // Act
-        await app.RunAsync();
+        await app.RunAsync(cancellationToken);
 
         // Assert
         var createHistories = ObjectStateHistory.Histories

--- a/samples/ConsoleAppWithDI/solution/tests/Maris.ConsoleApp.IntegrationTests/TestBase.cs
+++ b/samples/ConsoleAppWithDI/solution/tests/Maris.ConsoleApp.IntegrationTests/TestBase.cs
@@ -1,5 +1,4 @@
 ﻿using Maris.Logging.Testing.Xunit;
-using Xunit.Abstractions;
 
 namespace Maris.ConsoleApp.IntegrationTests;
 

--- a/samples/ConsoleAppWithDI/solution/tests/Maris.ConsoleApp.UnitTests/Core/AsyncCommandTest.cs
+++ b/samples/ConsoleAppWithDI/solution/tests/Maris.ConsoleApp.UnitTests/Core/AsyncCommandTest.cs
@@ -92,7 +92,7 @@ public class AsyncCommandTest
 
         // Assert
         var ex = Assert.Throws<InvalidOperationException>(action);
-        Assert.Equal($"invalid コンソールアプリケーションの実行コンテキストに設定されているパラメーター {typeof(ParameterWithInterface)} のオブジェクトを、コマンドクラスの実装時に指定した型 {typeof(CommandParameter)} として取り扱うことができません。 dummy-command コマンドまたはそのパラメーターの実装を修正してください。", ex.Message);
+        Assert.Equal($"コンソールアプリケーションの実行コンテキストに設定されているパラメーター {typeof(ParameterWithInterface)} のオブジェクトを、コマンドクラスの実装時に指定した型 {typeof(CommandParameter)} として取り扱うことができません。 dummy-command コマンドまたはそのパラメーターの実装を修正してください。", ex.Message);
     }
 
     public class CommandParameter

--- a/samples/ConsoleAppWithDI/solution/tests/Maris.ConsoleApp.UnitTests/Core/AsyncCommandTest.cs
+++ b/samples/ConsoleAppWithDI/solution/tests/Maris.ConsoleApp.UnitTests/Core/AsyncCommandTest.cs
@@ -92,7 +92,7 @@ public class AsyncCommandTest
 
         // Assert
         var ex = Assert.Throws<InvalidOperationException>(action);
-        Assert.Equal($"コンソールアプリケーションの実行コンテキストに設定されているパラメーター {typeof(ParameterWithInterface)} のオブジェクトを、コマンドクラスの実装時に指定した型 {typeof(CommandParameter)} として取り扱うことができません。 dummy-command コマンドまたはそのパラメーターの実装を修正してください。", ex.Message);
+        Assert.Equal($"invalid コンソールアプリケーションの実行コンテキストに設定されているパラメーター {typeof(ParameterWithInterface)} のオブジェクトを、コマンドクラスの実装時に指定した型 {typeof(CommandParameter)} として取り扱うことができません。 dummy-command コマンドまたはそのパラメーターの実装を修正してください。", ex.Message);
     }
 
     public class CommandParameter

--- a/samples/ConsoleAppWithDI/solution/tests/Maris.ConsoleApp.UnitTests/Hosting/ConsoleAppContextFactoryTest.cs
+++ b/samples/ConsoleAppWithDI/solution/tests/Maris.ConsoleApp.UnitTests/Hosting/ConsoleAppContextFactoryTest.cs
@@ -4,7 +4,6 @@ using CommandLine;
 using Maris.ConsoleApp.Core;
 using Maris.ConsoleApp.Hosting;
 using Microsoft.Extensions.Logging;
-using Xunit.Abstractions;
 
 namespace Maris.ConsoleApp.UnitTests.Hosting;
 

--- a/samples/ConsoleAppWithDI/solution/tests/Maris.ConsoleApp.UnitTests/Hosting/ConsoleAppHostedServiceTest.cs
+++ b/samples/ConsoleAppWithDI/solution/tests/Maris.ConsoleApp.UnitTests/Hosting/ConsoleAppHostedServiceTest.cs
@@ -3,7 +3,6 @@ using Maris.ConsoleApp.Hosting;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Time.Testing;
-using Xunit.Abstractions;
 
 namespace Maris.ConsoleApp.UnitTests.Hosting;
 
@@ -345,7 +344,7 @@ public class ConsoleAppHostedServiceTest(ITestOutputHelper testOutputHelper) : T
         var logger = this.CreateTestLogger<ConsoleAppHostedService>();
         var service = new ConsoleAppHostedService(lifetime, settings, executor, logger);
         var cancellationToken = new CancellationToken(false);
-
+        //TestContext.Current.
         // Act
         await service.StopAsync(cancellationToken);
 

--- a/samples/ConsoleAppWithDI/solution/tests/Maris.ConsoleApp.UnitTests/Hosting/ConsoleAppHostedServiceTest.cs
+++ b/samples/ConsoleAppWithDI/solution/tests/Maris.ConsoleApp.UnitTests/Hosting/ConsoleAppHostedServiceTest.cs
@@ -343,8 +343,8 @@ public class ConsoleAppHostedServiceTest(ITestOutputHelper testOutputHelper) : T
         var executor = new CommandExecutor(manager, commandExecutorLogger);
         var logger = this.CreateTestLogger<ConsoleAppHostedService>();
         var service = new ConsoleAppHostedService(lifetime, settings, executor, logger);
-        var cancellationToken = new CancellationToken(false);
-        //TestContext.Current.
+        var cancellationToken = TestContext.Current.CancellationToken;
+
         // Act
         await service.StopAsync(cancellationToken);
 

--- a/samples/ConsoleAppWithDI/solution/tests/Maris.ConsoleApp.UnitTests/Hosting/ServiceCollectionExtensionsTest.cs
+++ b/samples/ConsoleAppWithDI/solution/tests/Maris.ConsoleApp.UnitTests/Hosting/ServiceCollectionExtensionsTest.cs
@@ -4,7 +4,6 @@ using Maris.ConsoleApp.Core;
 using Maris.ConsoleApp.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Xunit.Abstractions;
 
 namespace Maris.ConsoleApp.UnitTests.Hosting;
 

--- a/samples/ConsoleAppWithDI/solution/tests/Maris.ConsoleApp.UnitTests/Maris.ConsoleApp.UnitTests.csproj
+++ b/samples/ConsoleAppWithDI/solution/tests/Maris.ConsoleApp.UnitTests/Maris.ConsoleApp.UnitTests.csproj
@@ -8,6 +8,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
     <PackageReference Include="Moq" />
     <PackageReference Include="StyleCop.Analyzers">
       <PrivateAssets>all</PrivateAssets>
@@ -15,10 +16,6 @@
     </PackageReference>
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/samples/ConsoleAppWithDI/solution/tests/Maris.ConsoleApp.UnitTests/Maris.ConsoleApp.UnitTests.csproj
+++ b/samples/ConsoleAppWithDI/solution/tests/Maris.ConsoleApp.UnitTests/Maris.ConsoleApp.UnitTests.csproj
@@ -13,7 +13,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/samples/ConsoleAppWithDI/solution/tests/Maris.ConsoleApp.UnitTests/TestBase.cs
+++ b/samples/ConsoleAppWithDI/solution/tests/Maris.ConsoleApp.UnitTests/TestBase.cs
@@ -1,7 +1,6 @@
 ﻿using Maris.Logging.Testing.Xunit;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Testing;
-using Xunit.Abstractions;
 
 namespace Maris.ConsoleApp.UnitTests;
 

--- a/samples/ConsoleAppWithDI/solution/tests/Maris.ConsoleApp.UnitTests/XunitSerializer/CommandBaseXunitSerializer.cs
+++ b/samples/ConsoleAppWithDI/solution/tests/Maris.ConsoleApp.UnitTests/XunitSerializer/CommandBaseXunitSerializer.cs
@@ -1,0 +1,11 @@
+﻿using Maris.ConsoleApp.Core;
+using Maris.ConsoleApp.UnitTests.XunitSerializer;
+using Xunit.Sdk;
+
+[assembly: RegisterXunitSerializer(typeof(CommandBaseXunitSerializer), typeof(CommandBase))]
+
+namespace Maris.ConsoleApp.UnitTests.XunitSerializer;
+
+public class CommandBaseXunitSerializer : JsonXunitSerializer<CommandBase>
+{
+}

--- a/samples/ConsoleAppWithDI/solution/tests/Maris.ConsoleApp.UnitTests/XunitSerializer/ConsoleAppContextXunitSerializer.cs
+++ b/samples/ConsoleAppWithDI/solution/tests/Maris.ConsoleApp.UnitTests/XunitSerializer/ConsoleAppContextXunitSerializer.cs
@@ -1,0 +1,11 @@
+﻿using Maris.ConsoleApp.Core;
+using Maris.ConsoleApp.UnitTests.XunitSerializer;
+using Xunit.Sdk;
+
+[assembly: RegisterXunitSerializer(typeof(ConsoleAppContextXunitSerializer), typeof(ConsoleAppContext))]
+
+namespace Maris.ConsoleApp.UnitTests.XunitSerializer;
+
+public class ConsoleAppContextXunitSerializer : JsonXunitSerializer<ConsoleAppContext>
+{
+}

--- a/samples/ConsoleAppWithDI/solution/tests/Maris.ConsoleApp.UnitTests/XunitSerializer/JsonXunitSerializer.cs
+++ b/samples/ConsoleAppWithDI/solution/tests/Maris.ConsoleApp.UnitTests/XunitSerializer/JsonXunitSerializer.cs
@@ -1,0 +1,37 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using Xunit.Sdk;
+
+namespace Maris.ConsoleApp.UnitTests.XunitSerializer;
+
+public class JsonXunitSerializer<T> : IXunitSerializer
+{
+    public object Deserialize(Type type, string serializedValue)
+    {
+        if (type == typeof(T))
+        {
+            var context = JsonSerializer.Deserialize<T>(serializedValue);
+            if (context is not null)
+            {
+                return context;
+            }
+        }
+
+        throw new NotSupportedException("デシリアライズに失敗しました。");
+    }
+
+    public bool IsSerializable(Type type, object? value, [NotNullWhen(false)] out string? failureReason)
+    {
+        if (type == typeof(T))
+        {
+            failureReason = null;
+            return true;
+        }
+
+        failureReason = "サポートされていない型です。";
+        return false;
+    }
+
+    public string Serialize(object value)
+        => JsonSerializer.Serialize(value);
+}


### PR DESCRIPTION
## この Pull request で実施したこと

テストフレームワークをxUnit v3に移行しました。
カバレッジ取得ツールを `Microsoft.Testing.Extensions.CodeCoverage` に変更しました。
`MemberData` で参照する型に対して、シリアル化ロジックを持つ `IXunitSerializer` を追加しました。
CI時のテストコマンドを修正しました。
PRにテスト結果を表示しないよう修正しました。

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

- <https://xunit.net/docs/getting-started/v3/custom-serialization>
- <https://github.com/tsuna-can-se/hello-world/pull/71>
- <https://github.com/tsuna-can-se/hello-world/pull/75>