### PR TITLE
Azure AD B2Cサンプルをxunit v3に移行する

### DIFF
--- a/.github/workflows/samples-azure-ad-b2c-auth-ci.yml
+++ b/.github/workflows/samples-azure-ad-b2c-auth-ci.yml
@@ -96,7 +96,6 @@ jobs:
     env:
       DOTNET_NOLOGO: true
       BUILD_CONFIGURATION: Debug
-      BUILD_SUMMARY_FILE: BuildSummary.md
     permissions:
       checks: write
     defaults:
@@ -141,38 +140,32 @@ jobs:
         name: テストの実行
         continue-on-error: true
         run: |
-          dotnet test --no-build --nologo --logger "trx;LogFileName=integration-test.trx" --logger:"console;verbosity=minimal" --verbosity normal --configuration ${{ env.BUILD_CONFIGURATION }} --collect "XPlat Code Coverage" > integration-test-result.txt
+          echo '## Test Result :memo:' >> $GITHUB_STEP_SUMMARY
+          dotnet test --no-build --nologo --verbosity normal --configuration ${{ env.BUILD_CONFIGURATION }} -- --coverage --coverage-output-format cobertura --coverage-output coverage.cobertura.xml --report-xunit-trx
 
       - id: create-test-result-report
         name: テスト結果ページの作成
-        uses: dorny/test-reporter@6e6a65b7a0bd2c9197df7d0ae36ac5cee784230c  # v2.0.0
-        if: ${{ success() || (failure() && steps.run-tests.conclusion == 'failure') }}
+        uses: dorny/test-reporter@v2
         with:
-          name: 'バックエンドのテスト結果'
+          name: 'Test results'
           path: '**/TestResults/*.trx'
           path-replace-backslashes: 'true'
           reporter: 'dotnet-trx'
           only-summary: 'false'
-          list-suites: 'all'
-          list-tests: 'all'
+          use-actions-summary: 'true'
+          badge-title: 'tests'
+          list-suites: 'failed'
+          list-tests: 'failed'
           max-annotations: '10'
-          fail-on-error: 'true'
-
-      - name: テスト結果のサマリー表示
-        shell: bash
-        if: ${{ success() || (failure() && steps.run-tests.conclusion == 'failure') }}
-        run: |
-          echo '## Test Result :memo:' >> ${{ env.BUILD_SUMMARY_FILE }}
-          echo 'Test was a **${{ steps.create-test-result-report.outputs.conclusion }}**.' >> ${{ env.BUILD_SUMMARY_FILE }}
-          echo 'Completed in ${{ steps.create-test-result-report.outputs.time }}ms with **${{ steps.create-test-result-report.outputs.passed }}** passed, **${{ steps.create-test-result-report.outputs.failed }}** failed and ${{ steps.create-test-result-report.outputs.skipped }} skipped.' >> ${{ env.BUILD_SUMMARY_FILE }}
-          cat ${{ env.BUILD_SUMMARY_FILE }} >> $GITHUB_STEP_SUMMARY
+          fail-on-error: 'false'
+          fail-on-empty: 'true'
 
       - id: create-coverage-report
         name: コードカバレッジレポートの解析と作成
         uses: danielpalme/ReportGenerator-GitHub-Action@f1927db1dbfc029b056583ee488832e939447fe6  # v5.4.4
         if: ${{ success() || (failure() && steps.run-tests.conclusion == 'failure') }}
         with:
-          reports: '**/TestResults/*/coverage.cobertura.xml'
+          reports: '**/TestResults/coverage.cobertura.xml'
           targetdir: '${{ env.BACKEND_WORKING_DIRECTORY }}/CoverageReport'
           reporttypes: 'MarkdownSummaryGithub'
 
@@ -183,4 +176,7 @@ jobs:
           sed -i s/'# Summary'/'## Coverage :triangular_ruler:'/g CoverageReport/SummaryGithub.md
           sed -i -e '/^## Coverage$/d' CoverageReport/SummaryGithub.md
           cat CoverageReport/SummaryGithub.md >> $GITHUB_STEP_SUMMARY
-          cat CoverageReport/SummaryGithub.md >> ${{ env.BUILD_SUMMARY_FILE }}
+
+      - name: 単体テスト結果の確認
+        if: ${{ steps.create-test-result-report.outputs.conclusion == 'failure' }}
+        run: exit 1

--- a/samples/AzureADB2CAuth/auth-backend/Directory.Packages.props
+++ b/samples/AzureADB2CAuth/auth-backend/Directory.Packages.props
@@ -1,4 +1,4 @@
-<Project>
+﻿<Project>
   <ItemGroup>
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.12" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.12" />
@@ -8,11 +8,11 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
     <PackageVersion Include="Microsoft.Identity.Web" Version="3.5.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.14.2" />
     <PackageVersion Include="NSwag.AspNetCore" Version="14.2.0" />
     <PackageVersion Include="NSwag.MSBuild" Version="14.2.0" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.1" />
     <PackageVersion Include="xunit.v3" Version="2.0.0" />
-    <PackageVersion Include="coverlet.collector" Version="6.0.3" />
   </ItemGroup>
 </Project>

--- a/samples/AzureADB2CAuth/auth-backend/Directory.Packages.props
+++ b/samples/AzureADB2CAuth/auth-backend/Directory.Packages.props
@@ -11,9 +11,8 @@
     <PackageVersion Include="NSwag.AspNetCore" Version="14.2.0" />
     <PackageVersion Include="NSwag.MSBuild" Version="14.2.0" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
-    <PackageVersion Include="xunit" Version="2.9.3" />
-    <PackageVersion Include="xunit.abstractions" Version="2.0.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.1" />
+    <PackageVersion Include="xunit.v3" Version="2.0.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.3" />
   </ItemGroup>
 </Project>

--- a/samples/AzureADB2CAuth/auth-backend/Dressca.sln
+++ b/samples/AzureADB2CAuth/auth-backend/Dressca.sln
@@ -24,6 +24,9 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dressca.IntegrationTest", "tests\Dressca.IntegrationTest\Dressca.IntegrationTest.csproj", "{D299C61B-0FF5-4D53-947F-8639BFC4BD49}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{A4862B43-6114-409B-AFE5-8485F4618852}"
+	ProjectSection(SolutionItems) = preProject
+		tests\Directory.Build.props = tests\Directory.Build.props
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/samples/AzureADB2CAuth/auth-backend/tests/Directory.Build.props
+++ b/samples/AzureADB2CAuth/auth-backend/tests/Directory.Build.props
@@ -1,0 +1,16 @@
+﻿<Project>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+  
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+  </PropertyGroup>
+
+   <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/samples/AzureADB2CAuth/auth-backend/tests/Dressca.IntegrationTest/ApiTest.cs
+++ b/samples/AzureADB2CAuth/auth-backend/tests/Dressca.IntegrationTest/ApiTest.cs
@@ -1,6 +1,5 @@
 ﻿using System.Net;
 using System.Net.Http.Headers;
-using Xunit;
 
 namespace Dressca.IntegrationTest;
 

--- a/samples/AzureADB2CAuth/auth-backend/tests/Dressca.IntegrationTest/ApiTest.cs
+++ b/samples/AzureADB2CAuth/auth-backend/tests/Dressca.IntegrationTest/ApiTest.cs
@@ -14,10 +14,11 @@ public class ApiTest(ApiTestWebApplicationFactory<Program> factory)
     {
         // Arrange
         var client = this.factory.CreateClient();
+        var cancellationToken = TestContext.Current.CancellationToken;
 
         // Act
         // 認証せずにリクエスト送信
-        var response = await client.GetAsync("api/users");
+        var response = await client.GetAsync("api/users", cancellationToken);
 
         // Assert
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
@@ -31,13 +32,14 @@ public class ApiTest(ApiTestWebApplicationFactory<Program> factory)
         // ログイン成功時に取得するJWTをヘッダーに追加
         var token = this.factory.CreateToken("testUser");
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var cancellationToken = TestContext.Current.CancellationToken;
 
         // Act
-        var response = await client.GetAsync("api/users");
+        var response = await client.GetAsync("api/users", cancellationToken);
 
         // Assert
         response.EnsureSuccessStatusCode();
-        var result = await response.Content.ReadAsStringAsync();
+        var result = await response.Content.ReadAsStringAsync(cancellationToken);
         Assert.Equal("{\"userId\":\"testUser\"}", result);
     }
 
@@ -46,13 +48,14 @@ public class ApiTest(ApiTestWebApplicationFactory<Program> factory)
     {
         // Arrange
         var client = this.factory.CreateClient();
+        var cancellationToken = TestContext.Current.CancellationToken;
 
         // Act
-        var response = await client.GetAsync("api/servertime");
+        var response = await client.GetAsync("api/serverTime", cancellationToken);
 
         // Assert
         response.EnsureSuccessStatusCode();
-        var result = await response.Content.ReadAsStringAsync();
+        var result = await response.Content.ReadAsStringAsync(cancellationToken);
         // "{"serverTime":"2024/04/12 13:32:59"}"
         Assert.StartsWith("{\"serverTime\":", result);
     }

--- a/samples/AzureADB2CAuth/auth-backend/tests/Dressca.IntegrationTest/ApiTestWebApplicationFactory.cs
+++ b/samples/AzureADB2CAuth/auth-backend/tests/Dressca.IntegrationTest/ApiTestWebApplicationFactory.cs
@@ -72,5 +72,4 @@ public class ApiTestWebApplicationFactory<TProgram>
                 .AddJsonFile($"appsettings.json", optional: true, reloadOnChange: true)
                 .Build();
     }
-
 }

--- a/samples/AzureADB2CAuth/auth-backend/tests/Dressca.IntegrationTest/Dressca.IntegrationTest.csproj
+++ b/samples/AzureADB2CAuth/auth-backend/tests/Dressca.IntegrationTest/Dressca.IntegrationTest.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 

--- a/samples/AzureADB2CAuth/auth-backend/tests/Dressca.IntegrationTest/Dressca.IntegrationTest.csproj
+++ b/samples/AzureADB2CAuth/auth-backend/tests/Dressca.IntegrationTest/Dressca.IntegrationTest.csproj
@@ -16,10 +16,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>


### PR DESCRIPTION
## この Pull request で実施したこと

Azure AD B2CサンプルをxUnit v3に移行しました。
コードカバレッジの取得ツールを `coverlet.collector` から `Microsoft.Testing.Extensions.CodeCoverage` に変更しました。
カバレッジ取得ツールの変更にあわせてワークフローを修正しました。

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

なし