### PR TITLE
ConsoleAppWithDIのNuGetパッケージを更新する

### DIFF
--- a/samples/ConsoleAppWithDI/solution/Directory.Packages.props
+++ b/samples/ConsoleAppWithDI/solution/Directory.Packages.props
@@ -5,13 +5,13 @@
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="8.10.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.14.2" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.1" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.2" />
     <PackageVersion Include="xunit.v3" Version="2.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## この Pull request で実施したこと

- `Microsoft.Extensions.Logging.Abstractions`を8.0.2から8.0.3に更新しました。
- `Microsoft.NET.Test.Sdk`を17.12.0から17.13.0に更新しました。
- `xunit.runner.visualstudio`を3.0.1から3.0.2に更新しました。

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

なし