### PR TITLE
Azure AD B2CサンプルのNuGetパッケージを更新する

### DIFF
--- a/samples/AzureADB2CAuth/auth-backend/Directory.Packages.props
+++ b/samples/AzureADB2CAuth/auth-backend/Directory.Packages.props
@@ -1,16 +1,16 @@
 ﻿<Project>
   <ItemGroup>
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.12" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.12" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.12" />
-    <PackageVersion Include="Microsoft.AspNetCore.SpaProxy" Version="8.0.12" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.14" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.14" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.14" />
+    <PackageVersion Include="Microsoft.AspNetCore.SpaProxy" Version="8.0.14" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
-    <PackageVersion Include="Microsoft.Identity.Web" Version="3.5.0" />
+    <PackageVersion Include="Microsoft.Identity.Web" Version="3.8.2" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.14.2" />
-    <PackageVersion Include="NSwag.AspNetCore" Version="14.2.0" />
-    <PackageVersion Include="NSwag.MSBuild" Version="14.2.0" />
+    <PackageVersion Include="NSwag.AspNetCore" Version="14.3.0" />
+    <PackageVersion Include="NSwag.MSBuild" Version="14.3.0" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.2" />
     <PackageVersion Include="xunit.v3" Version="2.0.0" />

--- a/samples/AzureADB2CAuth/auth-backend/Directory.Packages.props
+++ b/samples/AzureADB2CAuth/auth-backend/Directory.Packages.props
@@ -13,6 +13,6 @@
     <PackageVersion Include="NSwag.MSBuild" Version="14.3.0" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.2" />
-    <PackageVersion Include="xunit.v3" Version="2.0.0" />
+    <PackageVersion Include="xunit.v3" Version="2.0.1" />
   </ItemGroup>
 </Project>

--- a/samples/AzureADB2CAuth/auth-backend/src/Dressca.Web/dressca-api.json
+++ b/samples/AzureADB2CAuth/auth-backend/src/Dressca.Web/dressca-api.json
@@ -1,5 +1,5 @@
 {
-  "x-generator": "NSwag v14.2.0.0 (NJsonSchema v11.1.0.0 (Newtonsoft.Json v13.0.0.0))",
+  "x-generator": "NSwag v14.3.0.0 (NJsonSchema v11.2.0.0 (Newtonsoft.Json v13.0.0.0))",
   "openapi": "3.0.0",
   "info": {
     "title": "Azure AD B2C ユーザー認証",


### PR DESCRIPTION
## この Pull request で実施したこと

以下のパッケージのバージョンを更新しました：
- `Microsoft.AspNetCore.Authentication.JwtBearer`, `Microsoft.AspNetCore.Mvc.NewtonsoftJson`, `Microsoft.AspNetCore.Mvc.Testing`, `Microsoft.AspNetCore.SpaProxy`: 8.0.12 から 8.0.14
- `Microsoft.Identity.Web`: 3.5.0 から 3.8.2
- `NSwag.AspNetCore` と `NSwag.MSBuild`: 14.2.0 から 14.3.0
- `xunit.v3`：2.0.0 から 2.0.1

NSwag 系パッケージの更新に伴い、 OpenAPI仕様書を再生成しました。
バージョン番号以外の差異がないことを確認済みです。

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

なし