### PR TITLE
VSCode用のtextlint拡張機能を変更する

### DIFF
--- a/documents/README.md
+++ b/documents/README.md
@@ -211,7 +211,7 @@ CSpell の拡張機能をインストールしていると、 [問題] ウィン
 
 #### textlint
 
-vscode-textlint の拡張機能をインストールしていると、 [問題] ウィンドウに校正に関するコメントが出ます。
+textlint (VSCode extension) の拡張機能をインストールしていると、 [問題] ウィンドウに校正に関するコメントが出ます。
 この拡張機能は、技術ドキュメントを書く際の冗長な表現を排除したり、表記ゆれの検出したりする自動校正ツールです。
 多くの場合、文章の見直しによってエラーを回避できます。
 必ず対応するようにしてください。
@@ -397,7 +397,7 @@ Visual Studio Code の [ファイル] メニューから [ワークスペース�
 - [Draw.io integration](https://marketplace.visualstudio.com/items?itemName=hediet.vscode-drawio)
 - [Markdown All in One](https://marketplace.visualstudio.com/items?itemName=yzhang.markdown-all-in-one)
 - [markdownlint](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint)
-- [vscode-textlint](https://marketplace.visualstudio.com/items?itemName=3w36zj6.textlint)
+- [textlint (VSCode extension)](https://marketplace.visualstudio.com/items?itemName=3w36zj6.textlint)
 
 ![拡張機能メニュー](readme-images/recommend-vscode-extensions.png)
 

--- a/documents/README.md
+++ b/documents/README.md
@@ -211,7 +211,7 @@ CSpell の拡張機能をインストールしていると、 [問題] ウィン
 
 #### textlint
 
-textlint (VSCode 拡張機能) の拡張機能をインストールしていると、 [問題] ウィンドウに校正に関するコメントが出ます。
+textlint (VS Code 拡張機能) の拡張機能をインストールしていると、 [問題] ウィンドウに校正に関するコメントが出ます。
 この拡張機能は、技術ドキュメントを書く際の冗長な表現を排除したり、表記ゆれの検出したりする自動校正ツールです。
 多くの場合、文章の見直しによってエラーを回避できます。
 必ず対応するようにしてください。
@@ -397,7 +397,7 @@ Visual Studio Code の [ファイル] メニューから [ワークスペース�
 - [Draw.io integration](https://marketplace.visualstudio.com/items?itemName=hediet.vscode-drawio)
 - [Markdown All in One](https://marketplace.visualstudio.com/items?itemName=yzhang.markdown-all-in-one)
 - [markdownlint](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint)
-- [textlint (VSCode 拡張機能)](https://marketplace.visualstudio.com/items?itemName=3w36zj6.textlint)
+- [textlint (VS Code 拡張機能)](https://marketplace.visualstudio.com/items?itemName=3w36zj6.textlint)
 
 ![拡張機能メニュー](readme-images/recommend-vscode-extensions.png)
 

--- a/documents/README.md
+++ b/documents/README.md
@@ -211,7 +211,7 @@ CSpell の拡張機能をインストールしていると、 [問題] ウィン
 
 #### textlint
 
-textlint (VSCode extension) の拡張機能をインストールしていると、 [問題] ウィンドウに校正に関するコメントが出ます。
+textlint (VSCode 拡張機能) の拡張機能をインストールしていると、 [問題] ウィンドウに校正に関するコメントが出ます。
 この拡張機能は、技術ドキュメントを書く際の冗長な表現を排除したり、表記ゆれの検出したりする自動校正ツールです。
 多くの場合、文章の見直しによってエラーを回避できます。
 必ず対応するようにしてください。
@@ -397,7 +397,7 @@ Visual Studio Code の [ファイル] メニューから [ワークスペース�
 - [Draw.io integration](https://marketplace.visualstudio.com/items?itemName=hediet.vscode-drawio)
 - [Markdown All in One](https://marketplace.visualstudio.com/items?itemName=yzhang.markdown-all-in-one)
 - [markdownlint](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint)
-- [textlint (VSCode extension)](https://marketplace.visualstudio.com/items?itemName=3w36zj6.textlint)
+- [textlint (VSCode 拡張機能)](https://marketplace.visualstudio.com/items?itemName=3w36zj6.textlint)
 
 ![拡張機能メニュー](readme-images/recommend-vscode-extensions.png)
 

--- a/documents/README.md
+++ b/documents/README.md
@@ -397,7 +397,7 @@ Visual Studio Code の [ファイル] メニューから [ワークスペース�
 - [Draw.io integration](https://marketplace.visualstudio.com/items?itemName=hediet.vscode-drawio)
 - [Markdown All in One](https://marketplace.visualstudio.com/items?itemName=yzhang.markdown-all-in-one)
 - [markdownlint](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint)
-- [vscode-textlint](https://marketplace.visualstudio.com/items?itemName=taichi.vscode-textlint)
+- [vscode-textlint](https://marketplace.visualstudio.com/items?itemName=3w36zj6.textlint)
 
 ![拡張機能メニュー](readme-images/recommend-vscode-extensions.png)
 

--- a/maris.code-workspace
+++ b/maris.code-workspace
@@ -17,7 +17,7 @@
             "davidanson.vscode-markdownlint",
             "hediet.vscode-drawio",
             "shuworks.vscode-table-formatter",
-            "taichi.vscode-textlint",
+            "3w36zj6.textlint",
             "yzhang.markdown-all-in-one"
         ]
     }


### PR DESCRIPTION
Fixes #2575

## この Pull request で実施したこと

拡張機能のIDを修正しました。

- Change the extension ID in `maris.code-workspace` from `taichi.vscode-textlint` to `3w36zj6.textlint`.
- Update the extension ID in `documents/README.md` from `taichi.vscode-textlint` to `3w36zj6.textlint`.

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

なし

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/AlesInfiny/maris/pull/2582?shareId=732eaa9b-449e-441b-8403-3144bbbb9eaf).