### PR TITLE
StyleCop Analyzersの参照設定方法をグローバルパッケージ参照に変更

### DIFF
--- a/documents/contents/guidebooks/how-to-develop/dotnet/project-settings.md
+++ b/documents/contents/guidebooks/how-to-develop/dotnet/project-settings.md
@@ -258,7 +258,7 @@ Directory.Package.props ファイルで StyleCop Analyzers のグローバルパ
 <Project>
   <!-- StyleCop Analyzers 関連の設定以外省略 -->
   <ItemGroup>
-    <GlobalPackageReference Include="StyleCop.Analyzers" Version="x.x.x" PrivateAssets="All" />
+    <GlobalPackageReference Include="StyleCop.Analyzers" Version="x.x.x" />
   </ItemGroup>
 </Project>
 ```

--- a/documents/contents/guidebooks/how-to-develop/dotnet/project-settings.md
+++ b/documents/contents/guidebooks/how-to-develop/dotnet/project-settings.md
@@ -246,17 +246,22 @@ dotnet_diagnostic.SA1600.severity=none
 
 ### StyleCop Analyzers {#stylecop-analyzers}
 
-![stylecop.json ファイルの配置](../../../images/guidebooks/how-to-develop/dotnet/stylecop-json-placement-light.png#only-light){ loading=lazy align=right }
-![stylecop.json ファイルの配置](../../../images/guidebooks/how-to-develop/dotnet/stylecop-json-placement-dark.png#only-dark){ loading=lazy align=right }
-
 複数の開発者で、一貫したコーディングスタイルを維持するために利用します。
 .editorconfig では統一しきれない細かなコーディングルールを定義する目的に使用します。
 
 #### StyleCop Analyzers のインストール {#install-stylecop-analyzers}
 
 StyleCop Analyzers は [NuGet パッケージ :material-open-in-new:](https://www.nuget.org/packages/StyleCop.Analyzers/){ target=_blank } として提供されています。
-StyleCop Analyzers を用いて静的コード解析したいプロジェクトから参照設定を行ってください。
-通常はすべてのプロジェクトから参照するように設定します。
+Directory.Package.props ファイルで StyleCop Analyzers のグローバルパッケージ参照の設定をしてください。
+
+```props title="StyleCop Analyzers のグローバルパッケージ参照設定例"
+<Project>
+  <!-- StyleCop Analyzers 関連の設定以外省略 -->
+  <ItemGroup>
+    <GlobalPackageReference Include="StyleCop.Analyzers" Version="x.x.x" PrivateAssets="All" />
+  </ItemGroup>
+</Project>
+```
 
 !!! warning "StyleCop Analyzers のバージョンに注意"
 
@@ -321,7 +326,27 @@ stylecop.json の設定方法については [公式ドキュメント :material
     }
     ```
 
-#### プロジェクトから stylecop.json を参照する {#reference-stylecop-json-from-project}
+#### グローバルパッケージ参照を使用しない場合 {#without-global-package-reference}
+
+.NET SDK 7.0.100.preview7 より前のバージョンでは、グローバルパッケージ参照を使用できません。
+以下に、グローバルパッケージ参照を使用しない場合の StyleCop Analyzers の設定方法を示します。
+
+![stylecop.json ファイルの配置](../../../images/guidebooks/how-to-develop/dotnet/stylecop-json-placement-light.png#only-light){ loading=lazy align=right }
+![stylecop.json ファイルの配置](../../../images/guidebooks/how-to-develop/dotnet/stylecop-json-placement-dark.png#only-dark){ loading=lazy align=right }
+
+まず、 Directory.Package.props ファイルで StyleCop Analyzers のパッケージ参照の設定をしてください。
+
+```props
+<Project>
+  <ItemGroup>
+    <!-- StyleCop Analyzers 関連の設定以外省略 -->
+    <PackageVersion Include="StyleCop.Analyzers" Version="x.x.x" />
+  </ItemGroup>
+</Project>
+```
+
+次に、 StyleCop Analyzers を用いて静的コード解析したいプロジェクトで、 NuGet パッケージの参照設定を行ってください。
+通常は、すべてのプロジェクトから参照するように設定します。
 
 stylecop.json は、各プロジェクトのルートフォルダーにあるかのように設定しなければなりません。
 同時にコーディングルールの管理負荷軽減のため、 stylecop.json を各プロジェクトに分散配置せず、ソリューション内にひとつだけ配置することが望まれます。

--- a/documents/contents/guidebooks/how-to-develop/dotnet/project-settings.md
+++ b/documents/contents/guidebooks/how-to-develop/dotnet/project-settings.md
@@ -326,8 +326,12 @@ stylecop.json の設定方法については [公式ドキュメント :material
     }
     ```
 
+stylecop.json は、各プロジェクトのルートフォルダーにあるかのように設定しなければなりません。
+同時にコーディングルールの管理負荷軽減のため、 stylecop.json を各プロジェクトに分散配置せず、ソリューション内にひとつだけ配置することが望まれます。
+
 各プロジェクトからは、ソリューションルートに配置した stylecop.json をリンクとしてプロジェクトに追加しましょう。
 これにより、 StyleCop Analyzers の設定ファイルであることをコンパイラーに通知できます。
+ここまで解説した手順に対応すると、最終的にプロジェクトファイルの設定は以下のようになります。
 
 ![stylecop.json ファイルの配置](../../../images/guidebooks/how-to-develop/dotnet/stylecop-json-placement-light.png#only-light){ loading=lazy }
 ![stylecop.json ファイルの配置](../../../images/guidebooks/how-to-develop/dotnet/stylecop-json-placement-dark.png#only-dark){ loading=lazy }

--- a/documents/contents/guidebooks/how-to-develop/dotnet/project-settings.md
+++ b/documents/contents/guidebooks/how-to-develop/dotnet/project-settings.md
@@ -326,50 +326,17 @@ stylecop.json の設定方法については [公式ドキュメント :material
     }
     ```
 
-#### グローバルパッケージ参照を使用しない場合 {#without-global-package-reference}
-
-.NET SDK 7.0.100.preview7 より前のバージョンでは、グローバルパッケージ参照を使用できません。
-以下に、グローバルパッケージ参照を使用しない場合の StyleCop Analyzers の設定方法を示します。
-
-![stylecop.json ファイルの配置](../../../images/guidebooks/how-to-develop/dotnet/stylecop-json-placement-light.png#only-light){ loading=lazy align=right }
-![stylecop.json ファイルの配置](../../../images/guidebooks/how-to-develop/dotnet/stylecop-json-placement-dark.png#only-dark){ loading=lazy align=right }
-
-まず、 Directory.Package.props ファイルで StyleCop Analyzers のパッケージ参照の設定をしてください。
-
-```props
-<Project>
-  <ItemGroup>
-    <!-- StyleCop Analyzers 関連の設定以外省略 -->
-    <PackageVersion Include="StyleCop.Analyzers" Version="x.x.x" />
-  </ItemGroup>
-</Project>
-```
-
-次に、 StyleCop Analyzers を用いて静的コード解析したいプロジェクトで、 NuGet パッケージの参照設定を行ってください。
-通常は、すべてのプロジェクトから参照するように設定します。
-
-stylecop.json は、各プロジェクトのルートフォルダーにあるかのように設定しなければなりません。
-同時にコーディングルールの管理負荷軽減のため、 stylecop.json を各プロジェクトに分散配置せず、ソリューション内にひとつだけ配置することが望まれます。
-これらを両立するため、各プロジェクトからは、ソリューションルートに配置した stylecop.json をリンクとしてプロジェクトに追加しましょう。
-Visual Studio のソリューションエクスプローラーを利用して、 stylecop.json ファイルの [ビルドアクション] プロパティを [C# アナライザー追加ファイル] に設定します。
+各プロジェクトからは、ソリューションルートに配置した stylecop.json をリンクとしてプロジェクトに追加しましょう。
 これにより、 StyleCop Analyzers の設定ファイルであることをコンパイラーに通知できます。
 
-ここまで解説した手順に対応すると、最終的にプロジェクトファイルの設定は以下のようになります。
+![stylecop.json ファイルの配置](../../../images/guidebooks/how-to-develop/dotnet/stylecop-json-placement-light.png#only-light){ loading=lazy }
+![stylecop.json ファイルの配置](../../../images/guidebooks/how-to-develop/dotnet/stylecop-json-placement-dark.png#only-dark){ loading=lazy }
 
 ```xml title="プロジェクトファイルの設定例"
 <Project Sdk="Microsoft.NET.Sdk">
-
   <!-- StyleCop Analyzers 関連の設定以外省略 -->
-
   <ItemGroup>
     <AdditionalFiles Include="..\..\stylecop.json" Link="stylecop.json" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="StyleCop.Analyzers">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 </Project>
 ```

--- a/samples/AzureADB2CAuth/auth-backend/Directory.Build.props
+++ b/samples/AzureADB2CAuth/auth-backend/Directory.Build.props
@@ -1,5 +1,4 @@
 ﻿<Project>
-
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -8,9 +7,4 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
   </PropertyGroup>
-
-  <ItemGroup>
-    <AdditionalFiles Include="..\..\stylecop.json" Link="stylecop.json" />
-  </ItemGroup>
-
 </Project>

--- a/samples/AzureADB2CAuth/auth-backend/Directory.Build.props
+++ b/samples/AzureADB2CAuth/auth-backend/Directory.Build.props
@@ -1,4 +1,5 @@
 ﻿<Project>
+
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -7,7 +8,9 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
   </PropertyGroup>
+
   <ItemGroup>
     <AdditionalFiles Include="..\..\stylecop.json" Link="stylecop.json" />
   </ItemGroup>
+
 </Project>

--- a/samples/AzureADB2CAuth/auth-backend/Directory.Build.props
+++ b/samples/AzureADB2CAuth/auth-backend/Directory.Build.props
@@ -7,4 +7,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
   </PropertyGroup>
+  <ItemGroup>
+    <AdditionalFiles Include="..\..\stylecop.json" Link="stylecop.json" />
+  </ItemGroup>
 </Project>

--- a/samples/AzureADB2CAuth/auth-backend/Directory.Packages.props
+++ b/samples/AzureADB2CAuth/auth-backend/Directory.Packages.props
@@ -15,6 +15,6 @@
     <PackageVersion Include="xunit.v3" Version="2.0.1" />
   </ItemGroup>
   <ItemGroup>
-    <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" PrivateAssets="All" />
+    <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
   </ItemGroup>
 </Project>

--- a/samples/AzureADB2CAuth/auth-backend/Directory.Packages.props
+++ b/samples/AzureADB2CAuth/auth-backend/Directory.Packages.props
@@ -15,6 +15,6 @@
     <PackageVersion Include="xunit.v3" Version="2.0.1" />
   </ItemGroup>
   <ItemGroup>
-    <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
+    <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/samples/AzureADB2CAuth/auth-backend/Directory.Packages.props
+++ b/samples/AzureADB2CAuth/auth-backend/Directory.Packages.props
@@ -11,8 +11,10 @@
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.14.2" />
     <PackageVersion Include="NSwag.AspNetCore" Version="14.3.0" />
     <PackageVersion Include="NSwag.MSBuild" Version="14.3.0" />
-    <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.2" />
     <PackageVersion Include="xunit.v3" Version="2.0.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
   </ItemGroup>
 </Project>

--- a/samples/AzureADB2CAuth/auth-backend/src/Dressca.Web.Dto/Dressca.Web.Dto.csproj
+++ b/samples/AzureADB2CAuth/auth-backend/src/Dressca.Web.Dto/Dressca.Web.Dto.csproj
@@ -1,10 +1,2 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
-  <ItemGroup>
-    <PackageReference Include="StyleCop.Analyzers">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
 </Project>

--- a/samples/AzureADB2CAuth/auth-backend/src/Dressca.Web/Dressca.Web.csproj
+++ b/samples/AzureADB2CAuth/auth-backend/src/Dressca.Web/Dressca.Web.csproj
@@ -21,10 +21,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="StyleCop.Analyzers">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/AzureADB2CAuth/auth-backend/tests/.editorconfig
+++ b/samples/AzureADB2CAuth/auth-backend/tests/.editorconfig
@@ -1,0 +1,4 @@
+[*.cs]
+# Wrapping preferences
+dotnet_diagnostic.SA0001.severity=none
+dotnet_diagnostic.SA1600.severity=none

--- a/samples/AzureADB2CAuth/auth-backend/tests/Dressca.IntegrationTest/ApiTest.cs
+++ b/samples/AzureADB2CAuth/auth-backend/tests/Dressca.IntegrationTest/ApiTest.cs
@@ -28,6 +28,7 @@ public class ApiTest(ApiTestWebApplicationFactory<Program> factory)
     {
         // Arrange
         var client = this.factory.CreateClient();
+
         // ログイン成功時に取得するJWTをヘッダーに追加
         var token = this.factory.CreateToken("testUser");
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
@@ -55,6 +56,7 @@ public class ApiTest(ApiTestWebApplicationFactory<Program> factory)
         // Assert
         response.EnsureSuccessStatusCode();
         var result = await response.Content.ReadAsStringAsync(cancellationToken);
+
         // "{"serverTime":"2024/04/12 13:32:59"}"
         Assert.StartsWith("{\"serverTime\":", result);
     }

--- a/samples/AzureADB2CAuth/auth-backend/tests/Dressca.IntegrationTest/ApiTestWebApplicationFactory.cs
+++ b/samples/AzureADB2CAuth/auth-backend/tests/Dressca.IntegrationTest/ApiTestWebApplicationFactory.cs
@@ -13,34 +13,6 @@ public class ApiTestWebApplicationFactory<TProgram>
     : WebApplicationFactory<TProgram>
     where TProgram : class
 {
-    protected override void ConfigureWebHost(IWebHostBuilder builder)
-    {
-        builder.ConfigureServices(services =>
-        {
-            var config = this.GetConfiguration();
-
-            // テスト用のJwtBearer認証の設定追加
-            // デフォルトで認証に使用されるAuthenticationScheme名を"Test"に設定
-            services.AddAuthentication("Test")
-            .AddJwtBearer("Test", options =>
-            {
-                // JWTの検証内容を設定
-                options.TokenValidationParameters =
-                new TokenValidationParameters
-                {
-                    ValidIssuer = config["Jwt:Issuer"],
-                    ValidAudience = config["Jwt:Audience"],
-                    IssuerSigningKey = new SymmetricSecurityKey
-                        (Encoding.UTF8.GetBytes(config["Jwt:Key"] ?? throw new NullReferenceException("Jwt:Key"))),
-                    ValidateIssuer = true,
-                    ValidateAudience = true,
-                    ValidateLifetime = false,
-                    ValidateIssuerSigningKey = true
-                };
-            });
-        });
-    }
-
     internal string CreateToken(string userName)
     {
         // JWTの生成
@@ -51,7 +23,7 @@ public class ApiTestWebApplicationFactory<TProgram>
         var claims = new[]
         {
                 new Claim(JwtRegisteredClaimNames.Sub, userName),
-                new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString())
+                new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString()),
         };
 
         var token = new JwtSecurityToken(
@@ -71,5 +43,32 @@ public class ApiTestWebApplicationFactory<TProgram>
                 .SetBasePath(Directory.GetCurrentDirectory())
                 .AddJsonFile($"appsettings.json", optional: true, reloadOnChange: true)
                 .Build();
+    }
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.ConfigureServices(services =>
+        {
+            var config = this.GetConfiguration();
+
+            // テスト用のJwtBearer認証の設定追加
+            // デフォルトで認証に使用されるAuthenticationScheme名を"Test"に設定
+            services.AddAuthentication("Test")
+            .AddJwtBearer("Test", options =>
+            {
+                // JWTの検証内容を設定
+                options.TokenValidationParameters =
+                new TokenValidationParameters
+                {
+                    ValidIssuer = config["Jwt:Issuer"],
+                    ValidAudience = config["Jwt:Audience"],
+                    IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(config["Jwt:Key"] ?? throw new NullReferenceException("Jwt:Key"))),
+                    ValidateIssuer = true,
+                    ValidateAudience = true,
+                    ValidateLifetime = false,
+                    ValidateIssuerSigningKey = true,
+                };
+            });
+        });
     }
 }

--- a/samples/ConsoleAppWithDI/solution/Directory.Build.props
+++ b/samples/ConsoleAppWithDI/solution/Directory.Build.props
@@ -7,8 +7,4 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
   </PropertyGroup>
-
-  <ItemGroup>
-    <AdditionalFiles Include="..\..\stylecop.json" Link="stylecop.json" />
-  </ItemGroup>
 </Project>

--- a/samples/ConsoleAppWithDI/solution/Directory.Build.props
+++ b/samples/ConsoleAppWithDI/solution/Directory.Build.props
@@ -1,4 +1,5 @@
 ﻿<Project>
+
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -7,7 +8,9 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
   </PropertyGroup>
+
   <ItemGroup>
     <AdditionalFiles Include="..\..\stylecop.json" Link="stylecop.json" />
   </ItemGroup>
+
 </Project>

--- a/samples/ConsoleAppWithDI/solution/Directory.Build.props
+++ b/samples/ConsoleAppWithDI/solution/Directory.Build.props
@@ -7,4 +7,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
   </PropertyGroup>
+  <ItemGroup>
+    <AdditionalFiles Include="..\..\stylecop.json" Link="stylecop.json" />
+  </ItemGroup>
 </Project>

--- a/samples/ConsoleAppWithDI/solution/Directory.Packages.props
+++ b/samples/ConsoleAppWithDI/solution/Directory.Packages.props
@@ -14,6 +14,6 @@
     <PackageVersion Include="xunit.v3" Version="2.0.1" />
   </ItemGroup>
   <ItemGroup>
-    <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
+    <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/samples/ConsoleAppWithDI/solution/Directory.Packages.props
+++ b/samples/ConsoleAppWithDI/solution/Directory.Packages.props
@@ -14,6 +14,6 @@
     <PackageVersion Include="xunit.v3" Version="2.0.1" />
   </ItemGroup>
   <ItemGroup>
-    <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" PrivateAssets="All" />
+    <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
   </ItemGroup>
 </Project>

--- a/samples/ConsoleAppWithDI/solution/Directory.Packages.props
+++ b/samples/ConsoleAppWithDI/solution/Directory.Packages.props
@@ -10,8 +10,10 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.14.2" />
     <PackageVersion Include="Moq" Version="4.20.72" />
-    <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.2" />
     <PackageVersion Include="xunit.v3" Version="2.0.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
   </ItemGroup>
 </Project>

--- a/samples/ConsoleAppWithDI/solution/src/Maris.ConsoleApp.Core/Maris.ConsoleApp.Core.csproj
+++ b/samples/ConsoleAppWithDI/solution/src/Maris.ConsoleApp.Core/Maris.ConsoleApp.Core.csproj
@@ -7,10 +7,6 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
-    <PackageReference Include="StyleCop.Analyzers">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ConsoleAppWithDI/solution/src/Maris.ConsoleApp.Hosting/Maris.ConsoleApp.Hosting.csproj
+++ b/samples/ConsoleAppWithDI/solution/src/Maris.ConsoleApp.Hosting/Maris.ConsoleApp.Hosting.csproj
@@ -7,10 +7,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
-    <PackageReference Include="StyleCop.Analyzers">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ConsoleAppWithDI/solution/src/Maris.Samples.ApplicationCore/Events.cs
+++ b/samples/ConsoleAppWithDI/solution/src/Maris.Samples.ApplicationCore/Events.cs
@@ -7,15 +7,28 @@ namespace Maris.Samples.ApplicationCore;
 /// </summary>
 internal class Events
 {
-
+    /// <summary>
+    /// 指定した商品カテゴリの商品一覧の取得開始を示すイベント ID 。
+    /// </summary>
     internal static readonly EventId GetProductsByCategoryStart = new(1001, nameof(GetProductsByCategoryStart));
 
+    /// <summary>
+    /// 指定した商品カテゴリの商品一覧の取得終了を示すイベント ID 。
+    /// </summary>
     internal static readonly EventId GetProductsByCategoryNormalEnd = new(1002, nameof(GetProductsByCategoryNormalEnd));
 
+    /// <summary>
+    /// 指定した単価内の商品一覧の取得開始を示すイベント ID 。
+    /// </summary>
     internal static readonly EventId GetProductsByUnitPriceRangeStart = new(1003, nameof(GetProductsByUnitPriceRangeStart));
 
+    /// <summary>
+    /// 指定した単価内の商品一覧の取得終了を示すイベント ID 。
+    /// </summary>
     internal static readonly EventId GetProductsByUnitPriceRangeNormalEnd = new(1004, nameof(GetProductsByUnitPriceRangeNormalEnd));
 
+    /// <summary>
+    /// デバッグ用のイベント ID 。
+    /// </summary>
     internal static readonly EventId DebugEvent = new(9999, nameof(DebugEvent));
 }
-

--- a/samples/ConsoleAppWithDI/solution/src/Maris.Samples.ApplicationCore/ProductApplicationService.cs
+++ b/samples/ConsoleAppWithDI/solution/src/Maris.Samples.ApplicationCore/ProductApplicationService.cs
@@ -35,7 +35,7 @@ public class ProductApplicationService
     public List<Product> GetProductsByCategory(ProductCategory category)
     {
         this.logger.LogInformation(Events.GetProductsByCategoryStart, $"{category.Id} の商品情報を取得します。");
-        var products = productRepository.GetProductsByCategory(category);
+        var products = this.productRepository.GetProductsByCategory(category);
         this.logger.LogInformation(Events.GetProductsByCategoryNormalEnd, $"{category.CategoryName} の商品情報を {products.Count} 件取得しました。");
         return products;
     }
@@ -59,9 +59,8 @@ public class ProductApplicationService
         var minimumPrice = minPrice ?? decimal.MinValue;
         var maximumPrice = maxPrice ?? decimal.MaxValue;
         this.logger.LogInformation(Events.GetProductsByUnitPriceRangeStart, $"{minimumPrice} ～ {maximumPrice} の単価の商品情報を取得します。");
-        var products = await productRepository.GetProductsByUnitPriceRangeAsync(minimumPrice, maximumPrice, cancellationToken);
+        var products = await this.productRepository.GetProductsByUnitPriceRangeAsync(minimumPrice, maximumPrice, cancellationToken);
         this.logger.LogInformation(Events.GetProductsByUnitPriceRangeNormalEnd, $"{minimumPrice} ～ {maximumPrice} の単価の商品情報を {products.Count} 件取得しました。");
         return products;
-
     }
 }

--- a/samples/ConsoleAppWithDI/solution/src/Maris.Samples.Cli/Commands/CommandResult.cs
+++ b/samples/ConsoleAppWithDI/solution/src/Maris.Samples.Cli/Commands/CommandResult.cs
@@ -14,9 +14,16 @@ namespace Maris.Samples.Cli.Commands;
 /// </remarks>
 public class CommandResult : ICommandResult
 {
-    private static readonly int genericWarning = 1;
-    private static readonly int validationError = 10;
-    private static readonly int genericError = 99;
+    private static readonly int GenericWarningValue = 1;
+    private static readonly int ValidationErrorValue = 10;
+    private static readonly int GenericErrorValue = 99;
+
+    /// <summary>
+    ///  プロセスの終了コードを指定して
+    ///  <see cref="CommandResult"/> クラスの新しいインスタンスを初期化します。
+    /// </summary>
+    /// <param name="exitCode">プロセスの終了コード。</param>
+    protected CommandResult(int exitCode) => this.ExitCode = exitCode;
 
     /// <summary>
     ///  コマンドの成功を表す <see cref="ICommandResult"/> を取得します。
@@ -26,29 +33,22 @@ public class CommandResult : ICommandResult
     /// <summary>
     ///  汎用の警告終了を表す <see cref="ICommandResult"/> を取得します。
     /// </summary>
-    public static ICommandResult GenericWarning => CreateWarning(genericWarning);
+    public static ICommandResult GenericWarning => CreateWarning(GenericWarningValue);
 
     /// <summary>
     ///  起動パラメーターの入力値検証に失敗したことを表す <see cref="ICommandResult"/> を取得します。
     /// </summary>
-    public static ICommandResult ValidationError => CreateError(validationError);
+    public static ICommandResult ValidationError => CreateError(ValidationErrorValue);
 
     /// <summary>
     ///  汎用の異常終了を表す <see cref="ICommandResult"/> を取得します。
     /// </summary>
-    public static ICommandResult GenericError => CreateError(genericError);
+    public static ICommandResult GenericError => CreateError(GenericErrorValue);
 
     /// <summary>
     ///  プロセスの終了コードを取得します。
     /// </summary>
     public int ExitCode { get; }
-
-    /// <summary>
-    ///  プロセスの終了コードを指定して
-    ///  <see cref="CommandResult"/> クラスの新しいインスタンスを初期化します。
-    /// </summary>
-    /// <param name="exitCode">プロセスの終了コード。</param>
-    protected CommandResult(int exitCode) => this.ExitCode = exitCode;
 
     /// <summary>
     ///  警告終了を表す <see cref="ICommandResult"/> を取得します。
@@ -89,9 +89,10 @@ public class CommandResult : ICommandResult
         ///   <item><paramref name="exitCode"/> に 1 ～ 9 以外の値が指定されました。</item>
         ///  </list>
         /// </exception>
-        internal WarningCommandResult(int exitCode) : base(exitCode)
+        internal WarningCommandResult(int exitCode)
+            : base(exitCode)
         {
-            if (exitCode < 1 || 9 < exitCode)
+            if (exitCode < 1 || exitCode > 9)
             {
                 throw new ArgumentOutOfRangeException(
                     nameof(exitCode),
@@ -118,9 +119,10 @@ public class CommandResult : ICommandResult
         ///   <item><paramref name="exitCode"/> に 10 ～ 99 以外の値が指定されました。</item>
         ///  </list>
         /// </exception>
-        internal ErrorCommandResult(int exitCode) : base(exitCode)
+        internal ErrorCommandResult(int exitCode)
+            : base(exitCode)
         {
-            if (exitCode < 10 || 99 < exitCode)
+            if (exitCode < 10 || exitCode > 99)
             {
                 throw new ArgumentOutOfRangeException(
                     nameof(exitCode),

--- a/samples/ConsoleAppWithDI/solution/src/Maris.Samples.Cli/Commands/GetProductsByUnitPriceRange/Command.cs
+++ b/samples/ConsoleAppWithDI/solution/src/Maris.Samples.Cli/Commands/GetProductsByUnitPriceRange/Command.cs
@@ -42,9 +42,9 @@ internal class Command : AsyncCommand<Parameter>
             parameter.MinimumUnitPrice, parameter.MaximumUnitPrice, cancellationToken);
         if (products.Count >= 10)
         {
-            this.logger.LogWarning(Events.Over10ProductsFoundInRange, $"単価が {parameter.MinimumUnitPrice} ～ " +
-                $"{parameter.MaximumUnitPrice} の商品情報が 10 件以上あります。" +
-                $"範囲を絞り込んでください。");
+            this.logger.LogWarning(
+                Events.Over10ProductsFoundInRange,
+                $"単価が {parameter.MinimumUnitPrice} ～ " + $"{parameter.MaximumUnitPrice} の商品情報が 10 件以上あります。" + $"範囲を絞り込んでください。");
             return CommandResult.CreateWarning(2);
         }
 

--- a/samples/ConsoleAppWithDI/solution/src/Maris.Samples.Cli/Events.cs
+++ b/samples/ConsoleAppWithDI/solution/src/Maris.Samples.Cli/Events.cs
@@ -7,7 +7,13 @@ namespace Maris.Samples.Cli;
 /// </summary>
 internal class Events
 {
+    /// <summary>
+    /// 指定した検索条件で取得した商品情報が 10 件以上であることを示すイベント ID 。
+    /// </summary>
     internal static readonly EventId Over10ProductsFoundInRange = new(1001, nameof(Over10ProductsFoundInRange));
 
+    /// <summary>
+    /// デバッグ用のイベント ID 。
+    /// </summary>
     internal static readonly EventId DebugEvent = new(9999, nameof(DebugEvent));
 }

--- a/samples/ConsoleAppWithDI/solution/src/Maris.Samples.Cli/Program.cs
+++ b/samples/ConsoleAppWithDI/solution/src/Maris.Samples.Cli/Program.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Hosting;
 var builder = Host.CreateDefaultBuilder(args);
 builder.ConfigureServices((context, services) =>
 {
-    //コマンド内で利用するクラス群を DI コンテナーに登録
+    // コマンド内で利用するクラス群を DI コンテナーに登録
     services.AddScoped<ProductApplicationService>();
     services.AddScoped<IProductsRepository, ProductsRepository>();
 

--- a/samples/ConsoleAppWithDI/solution/src/Maris.Samples.InMemoryInfrastructure/ProductsRepository.cs
+++ b/samples/ConsoleAppWithDI/solution/src/Maris.Samples.InMemoryInfrastructure/ProductsRepository.cs
@@ -8,56 +8,55 @@ namespace Maris.Samples.InMemoryInfrastructure;
 /// </summary>
 public class ProductsRepository : IProductsRepository
 {
-    private static readonly List<ProductCategory> categories;
-    private static readonly List<Product> products;
+    private static readonly List<ProductCategory> Categories;
+    private static readonly List<Product> Products;
 
     static ProductsRepository()
     {
-        categories =
+        Categories =
         [
             new ProductCategory { Id = 1, CategoryName = "本" },
             new ProductCategory { Id = 2, CategoryName = "音楽" },
             new ProductCategory { Id = 3, CategoryName = "パソコン" },
         ];
 
-        products =
+        Products =
         [
-            new Product() { Id = 1, Name = "本1", ProductCategoryId = 1, ProductCategory = categories[0], UnitPrice = 1000 },
-            new Product() { Id = 2, Name = "本2", ProductCategoryId = 1, ProductCategory = categories[0], UnitPrice = 1100 },
-            new Product() { Id = 3, Name = "本3", ProductCategoryId = 1, ProductCategory = categories[0], UnitPrice = 1200 },
-            new Product() { Id = 4, Name = "本4", ProductCategoryId = 1, ProductCategory = categories[0], UnitPrice = 1300 },
-            new Product() { Id = 5, Name = "本5", ProductCategoryId = 1, ProductCategory = categories[0], UnitPrice = 1400 },
-            new Product() { Id = 6, Name = "本6", ProductCategoryId = 1, ProductCategory = categories[0], UnitPrice = 1500 },
-            new Product() { Id = 7, Name = "本7", ProductCategoryId = 1, ProductCategory = categories[0], UnitPrice = 1600 },
-            new Product() { Id = 8, Name = "本8", ProductCategoryId = 1, ProductCategory = categories[0], UnitPrice = 1700 },
-            new Product() { Id = 9, Name = "本9", ProductCategoryId = 1, ProductCategory = categories[0], UnitPrice = 1800 },
-            new Product() { Id = 10, Name = "本10", ProductCategoryId = 1, ProductCategory = categories[0], UnitPrice = 1900 },
-            new Product() { Id = 11, Name = "Music 1", ProductCategoryId = 2, ProductCategory = categories[1], UnitPrice = 2000 },
-            new Product() { Id = 12, Name = "Music 2", ProductCategoryId = 2, ProductCategory = categories[1], UnitPrice = 2100 },
-            new Product() { Id = 13, Name = "Music 3", ProductCategoryId = 2, ProductCategory = categories[1], UnitPrice = 2200 },
-            new Product() { Id = 14, Name = "Music 4", ProductCategoryId = 2, ProductCategory = categories[1], UnitPrice = 2300 },
-            new Product() { Id = 15, Name = "Music 5", ProductCategoryId = 2, ProductCategory = categories[1], UnitPrice = 2400 },
-            new Product() { Id = 16, Name = "Music 6", ProductCategoryId = 2, ProductCategory = categories[1], UnitPrice = 2500 },
-            new Product() { Id = 17, Name = "パソコン 1", ProductCategoryId = 3, ProductCategory = categories[2], UnitPrice = 200000 },
-            new Product() { Id = 18, Name = "パソコン 2", ProductCategoryId = 3, ProductCategory = categories[2], UnitPrice = 210000 },
-            new Product() { Id = 19, Name = "パソコン 3", ProductCategoryId = 3, ProductCategory = categories[2], UnitPrice = 220000 },
-            new Product() { Id = 20, Name = "パソコン 4", ProductCategoryId = 3, ProductCategory = categories[2], UnitPrice = 230000 },
-            new Product() { Id = 21, Name = "パソコン 5", ProductCategoryId = 3, ProductCategory = categories[2], UnitPrice = 240000 },
-            new Product() { Id = 22, Name = "パソコン 6", ProductCategoryId = 3, ProductCategory = categories[2], UnitPrice = 250000 },
-            new Product() { Id = 23, Name = "パソコン 7", ProductCategoryId = 3, ProductCategory = categories[2], UnitPrice = 260000 },
-            new Product() { Id = 24, Name = "パソコン 8", ProductCategoryId = 3, ProductCategory = categories[2], UnitPrice = 270000 },
+            new Product() { Id = 1, Name = "本1", ProductCategoryId = 1, ProductCategory = Categories[0], UnitPrice = 1000 },
+            new Product() { Id = 2, Name = "本2", ProductCategoryId = 1, ProductCategory = Categories[0], UnitPrice = 1100 },
+            new Product() { Id = 3, Name = "本3", ProductCategoryId = 1, ProductCategory = Categories[0], UnitPrice = 1200 },
+            new Product() { Id = 4, Name = "本4", ProductCategoryId = 1, ProductCategory = Categories[0], UnitPrice = 1300 },
+            new Product() { Id = 5, Name = "本5", ProductCategoryId = 1, ProductCategory = Categories[0], UnitPrice = 1400 },
+            new Product() { Id = 6, Name = "本6", ProductCategoryId = 1, ProductCategory = Categories[0], UnitPrice = 1500 },
+            new Product() { Id = 7, Name = "本7", ProductCategoryId = 1, ProductCategory = Categories[0], UnitPrice = 1600 },
+            new Product() { Id = 8, Name = "本8", ProductCategoryId = 1, ProductCategory = Categories[0], UnitPrice = 1700 },
+            new Product() { Id = 9, Name = "本9", ProductCategoryId = 1, ProductCategory = Categories[0], UnitPrice = 1800 },
+            new Product() { Id = 10, Name = "本10", ProductCategoryId = 1, ProductCategory = Categories[0], UnitPrice = 1900 },
+            new Product() { Id = 11, Name = "Music 1", ProductCategoryId = 2, ProductCategory = Categories[1], UnitPrice = 2000 },
+            new Product() { Id = 12, Name = "Music 2", ProductCategoryId = 2, ProductCategory = Categories[1], UnitPrice = 2100 },
+            new Product() { Id = 13, Name = "Music 3", ProductCategoryId = 2, ProductCategory = Categories[1], UnitPrice = 2200 },
+            new Product() { Id = 14, Name = "Music 4", ProductCategoryId = 2, ProductCategory = Categories[1], UnitPrice = 2300 },
+            new Product() { Id = 15, Name = "Music 5", ProductCategoryId = 2, ProductCategory = Categories[1], UnitPrice = 2400 },
+            new Product() { Id = 16, Name = "Music 6", ProductCategoryId = 2, ProductCategory = Categories[1], UnitPrice = 2500 },
+            new Product() { Id = 17, Name = "パソコン 1", ProductCategoryId = 3, ProductCategory = Categories[2], UnitPrice = 200000 },
+            new Product() { Id = 18, Name = "パソコン 2", ProductCategoryId = 3, ProductCategory = Categories[2], UnitPrice = 210000 },
+            new Product() { Id = 19, Name = "パソコン 3", ProductCategoryId = 3, ProductCategory = Categories[2], UnitPrice = 220000 },
+            new Product() { Id = 20, Name = "パソコン 4", ProductCategoryId = 3, ProductCategory = Categories[2], UnitPrice = 230000 },
+            new Product() { Id = 21, Name = "パソコン 5", ProductCategoryId = 3, ProductCategory = Categories[2], UnitPrice = 240000 },
+            new Product() { Id = 22, Name = "パソコン 6", ProductCategoryId = 3, ProductCategory = Categories[2], UnitPrice = 250000 },
+            new Product() { Id = 23, Name = "パソコン 7", ProductCategoryId = 3, ProductCategory = Categories[2], UnitPrice = 260000 },
+            new Product() { Id = 24, Name = "パソコン 8", ProductCategoryId = 3, ProductCategory = Categories[2], UnitPrice = 270000 },
         ];
-
     }
 
     /// <inheritdoc/>
     public List<Product> GetProductsByCategory(ProductCategory productCategory)
     {
-        productCategory.CategoryName = categories.Where(c => c.Id == productCategory.Id).Select(c => c.CategoryName).First();
-        return products.Where(p => p.ProductCategoryId == productCategory.Id).ToList();
+        productCategory.CategoryName = Categories.Where(c => c.Id == productCategory.Id).Select(c => c.CategoryName).First();
+        return Products.Where(p => p.ProductCategoryId == productCategory.Id).ToList();
     }
 
     /// <inheritdoc/>
     public Task<List<Product>> GetProductsByUnitPriceRangeAsync(decimal minPrice, decimal maxPrice, CancellationToken cancellationToken)
-        => Task.FromResult(products.Where(p => minPrice <= p.UnitPrice && p.UnitPrice <= maxPrice).ToList());
+        => Task.FromResult(Products.Where(p => minPrice <= p.UnitPrice && p.UnitPrice <= maxPrice).ToList());
 }

--- a/samples/ConsoleAppWithDI/solution/tests/Maris.ConsoleApp.IntegrationTests/Maris.ConsoleApp.IntegrationTests.csproj
+++ b/samples/ConsoleAppWithDI/solution/tests/Maris.ConsoleApp.IntegrationTests/Maris.ConsoleApp.IntegrationTests.csproj
@@ -6,10 +6,6 @@
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
-    <PackageReference Include="StyleCop.Analyzers">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/samples/ConsoleAppWithDI/solution/tests/Maris.ConsoleApp.UnitTests/Maris.ConsoleApp.UnitTests.csproj
+++ b/samples/ConsoleAppWithDI/solution/tests/Maris.ConsoleApp.UnitTests/Maris.ConsoleApp.UnitTests.csproj
@@ -11,10 +11,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
     <PackageReference Include="Moq" />
-    <PackageReference Include="StyleCop.Analyzers">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/samples/Dressca/dressca-backend/Directory.Build.props
+++ b/samples/Dressca/dressca-backend/Directory.Build.props
@@ -1,5 +1,4 @@
 ﻿<Project>
-
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -8,9 +7,4 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
   </PropertyGroup>
-
-  <ItemGroup>
-    <AdditionalFiles Include="..\..\stylecop.json" Link="stylecop.json" />
-  </ItemGroup>
-
 </Project>

--- a/samples/Dressca/dressca-backend/Directory.Build.props
+++ b/samples/Dressca/dressca-backend/Directory.Build.props
@@ -1,4 +1,5 @@
 ﻿<Project>
+
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -7,7 +8,9 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
   </PropertyGroup>
+
   <ItemGroup>
     <AdditionalFiles Include="..\..\stylecop.json" Link="stylecop.json" />
   </ItemGroup>
+
 </Project>

--- a/samples/Dressca/dressca-backend/Directory.Build.props
+++ b/samples/Dressca/dressca-backend/Directory.Build.props
@@ -7,4 +7,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
   </PropertyGroup>
+  <ItemGroup>
+    <AdditionalFiles Include="..\..\stylecop.json" Link="stylecop.json" />
+  </ItemGroup>
 </Project>

--- a/samples/Dressca/dressca-backend/Directory.Packages.props
+++ b/samples/Dressca/dressca-backend/Directory.Packages.props
@@ -20,6 +20,6 @@
     <PackageVersion Include="xunit.v3" Version="2.0.1" />
   </ItemGroup>
   <ItemGroup>
-    <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556"/>
+    <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/samples/Dressca/dressca-backend/Directory.Packages.props
+++ b/samples/Dressca/dressca-backend/Directory.Packages.props
@@ -20,6 +20,6 @@
     <PackageVersion Include="xunit.v3" Version="2.0.1" />
   </ItemGroup>
   <ItemGroup>
-    <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" PrivateAssets="All" />
+    <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
   </ItemGroup>
 </Project>

--- a/samples/Dressca/dressca-backend/Directory.Packages.props
+++ b/samples/Dressca/dressca-backend/Directory.Packages.props
@@ -16,8 +16,10 @@
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="NSwag.AspNetCore" Version="14.3.0" />
     <PackageVersion Include="NSwag.MSBuild" Version="14.3.0" />
-    <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.2" />
     <PackageVersion Include="xunit.v3" Version="2.0.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556"/>
   </ItemGroup>
 </Project>

--- a/samples/Dressca/dressca-backend/src/Dressca.ApplicationCore/Dressca.ApplicationCore.csproj
+++ b/samples/Dressca/dressca-backend/src/Dressca.ApplicationCore/Dressca.ApplicationCore.csproj
@@ -3,10 +3,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
-    <PackageReference Include="StyleCop.Analyzers">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Dressca/dressca-backend/src/Dressca.EfInfrastructure/Dressca.EfInfrastructure.csproj
+++ b/samples/Dressca/dressca-backend/src/Dressca.EfInfrastructure/Dressca.EfInfrastructure.csproj
@@ -7,10 +7,6 @@
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" />
-    <PackageReference Include="StyleCop.Analyzers">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Dressca/dressca-backend/src/Dressca.Store.Assets.StaticFiles/Dressca.Store.Assets.StaticFiles.csproj
+++ b/samples/Dressca/dressca-backend/src/Dressca.Store.Assets.StaticFiles/Dressca.Store.Assets.StaticFiles.csproj
@@ -1,11 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <ItemGroup>
-    <PackageReference Include="StyleCop.Analyzers">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Dressca.ApplicationCore\Dressca.ApplicationCore.csproj" />

--- a/samples/Dressca/dressca-backend/src/Dressca.SystemCommon/Dressca.SystemCommon.csproj
+++ b/samples/Dressca/dressca-backend/src/Dressca.SystemCommon/Dressca.SystemCommon.csproj
@@ -1,13 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <PackageReference Include="StyleCop.Analyzers">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup>
     <Compile Update="Resources\Messages.Designer.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>

--- a/samples/Dressca/dressca-backend/src/Dressca.Web.Admin.Dto/Dressca.Web.Admin.Dto.csproj
+++ b/samples/Dressca/dressca-backend/src/Dressca.Web.Admin.Dto/Dressca.Web.Admin.Dto.csproj
@@ -1,10 +1,2 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
-  <ItemGroup>
-    <PackageReference Include="StyleCop.Analyzers">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
 </Project>

--- a/samples/Dressca/dressca-backend/src/Dressca.Web.Admin/Dressca.Web.Admin.csproj
+++ b/samples/Dressca/dressca-backend/src/Dressca.Web.Admin/Dressca.Web.Admin.csproj
@@ -20,10 +20,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="StyleCop.Analyzers">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
   
   <ItemGroup>

--- a/samples/Dressca/dressca-backend/src/Dressca.Web.Consumer.Dto/Dressca.Web.Consumer.Dto.csproj
+++ b/samples/Dressca/dressca-backend/src/Dressca.Web.Consumer.Dto/Dressca.Web.Consumer.Dto.csproj
@@ -1,10 +1,2 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
-  <ItemGroup>
-    <PackageReference Include="StyleCop.Analyzers">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
 </Project>

--- a/samples/Dressca/dressca-backend/src/Dressca.Web.Consumer/Dressca.Web.Consumer.csproj
+++ b/samples/Dressca/dressca-backend/src/Dressca.Web.Consumer/Dressca.Web.Consumer.csproj
@@ -21,10 +21,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="StyleCop.Analyzers">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Dressca/dressca-backend/src/Dressca.Web/Dressca.Web.csproj
+++ b/samples/Dressca/dressca-backend/src/Dressca.Web/Dressca.Web.csproj
@@ -6,10 +6,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" />
-    <PackageReference Include="StyleCop.Analyzers">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Dressca/dressca-backend/tests/Dressca.IntegrationTest/Dressca.IntegrationTest.csproj
+++ b/samples/Dressca/dressca-backend/tests/Dressca.IntegrationTest/Dressca.IntegrationTest.csproj
@@ -10,10 +10,6 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
-    <PackageReference Include="StyleCop.Analyzers">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.ApplicationCore/Dressca.UnitTests.ApplicationCore.csproj
+++ b/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.ApplicationCore/Dressca.UnitTests.ApplicationCore.csproj
@@ -14,10 +14,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
     <PackageReference Include="Moq" />
-    <PackageReference Include="StyleCop.Analyzers">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.SystemCommon/Dressca.UnitTests.SystemCommon.csproj
+++ b/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.SystemCommon/Dressca.UnitTests.SystemCommon.csproj
@@ -12,10 +12,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
     <PackageReference Include="Moq" />
-    <PackageReference Include="StyleCop.Analyzers">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.Web.Admin/Dressca.UnitTests.Web.Admin.csproj
+++ b/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.Web.Admin/Dressca.UnitTests.Web.Admin.csproj
@@ -9,10 +9,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
     <PackageReference Include="Moq" />
-    <PackageReference Include="StyleCop.Analyzers">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.Web.Consumer/Dressca.UnitTests.Web.Consumer.csproj
+++ b/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.Web.Consumer/Dressca.UnitTests.Web.Consumer.csproj
@@ -14,10 +14,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
     <PackageReference Include="Moq" />
-    <PackageReference Include="StyleCop.Analyzers">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.Web/Dressca.UnitTests.Web.csproj
+++ b/samples/Dressca/dressca-backend/tests/Dressca.UnitTests.Web/Dressca.UnitTests.Web.csproj
@@ -8,10 +8,6 @@
     <PackageReference Include="Maris.Logging.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
-    <PackageReference Include="StyleCop.Analyzers">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/samples/Dressca/dressca-backend/tests/Dressca.Web.Admin.IntegrationTest/Dressca.Web.Admin.IntegrationTest.csproj
+++ b/samples/Dressca/dressca-backend/tests/Dressca.Web.Admin.IntegrationTest/Dressca.Web.Admin.IntegrationTest.csproj
@@ -10,10 +10,6 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
-    <PackageReference Include="StyleCop.Analyzers">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## この Pull request で実施したこと

- Dresscaサンプル、Consoleサンプル、ADB2Cサンプルそれぞれについて以下を実施しました。
  - それぞれの Directory.Package.config に StyleCop Analyzers のグローバルパッケージ参照の設定を追加しました。
  - 各プロジェクトの参照設定からStyleCop Analyzersを削除しました。
  - 発生した警告に対応しました。
    - ADB2C サンプルおよび Console サンプルの一部プロジェクトで、csprojファイルに StyleCop Analyzers の設定漏れがありました。今回グローバルパッケージ参照にしたことにより、それらのプロジェクトにも StyleCop Analyzers の設定が適用されたため新たに警告が発生しました。
- StyleCop Analyzersの設定手順のドキュメントを修正しました。

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

- #2684

<!-- I want to review in Japanese. -->