### PR TITLE
DresscaのNuGetパッケージを更新する

### DIFF
--- a/samples/Dressca/dressca-backend/Directory.Packages.props
+++ b/samples/Dressca/dressca-backend/Directory.Packages.props
@@ -1,23 +1,23 @@
 <Project>
   <ItemGroup>
-    <PackageVersion Include="Maris.Logging.Testing" Version="1.0.0" />
+    <PackageVersion Include="Maris.Logging.Testing" Version="1.1.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.16" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.16" />
     <PackageVersion Include="Microsoft.AspNetCore.SpaProxy" Version="8.0.16" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="8.0.16" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.16" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.16" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="8.0.17" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.17" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.17" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.16" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="8.10.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.14.2" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="NSwag.AspNetCore" Version="14.4.0" />
     <PackageVersion Include="NSwag.MSBuild" Version="14.4.0" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.0" />
-    <PackageVersion Include="xunit.v3" Version="2.0.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.1" />
+    <PackageVersion Include="xunit.v3" Version="2.0.3" />
   </ItemGroup>
   <ItemGroup>
     <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## この Pull request で実施したこと

以下のパッケージを最新の.NET 8系に更新しました。
- `Maris.Logging.Testing` 1.0.0 -> 1.1.0
- `Microsoft.EntityFrameworkCore` 8.0.16 -> 8.0.17
- `Microsoft.EntityFrameworkCore.Design` 8.0.16 -> 8.0.17
- `Microsoft.EntityFrameworkCore.SqlServer` 8.0.16 -> 8.0.17
- `Microsoft.NET.Test.Sdk `17.13.0 -> 17.14.1
- `xunit.runner.visualstudio` 3.1.0 -> 3.1.1
- `xunit.v3` 2.0.2 -> 2.0.3

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

なし

<!-- I want to review in Japanese. -->