### PR TITLE
AzureADB2CAuthのNuGetパッケージを更新

### DIFF
--- a/samples/AzureADB2CAuth/auth-backend/Directory.Packages.props
+++ b/samples/AzureADB2CAuth/auth-backend/Directory.Packages.props
@@ -1,18 +1,18 @@
 ﻿<Project>
   <ItemGroup>
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.14" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.14" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.14" />
-    <PackageVersion Include="Microsoft.AspNetCore.SpaProxy" Version="8.0.14" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.17" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.17" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.17" />
+    <PackageVersion Include="Microsoft.AspNetCore.SpaProxy" Version="8.0.17" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
-    <PackageVersion Include="Microsoft.Identity.Web" Version="3.8.2" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageVersion Include="Microsoft.Identity.Web" Version="3.9.3" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.14.2" />
-    <PackageVersion Include="NSwag.AspNetCore" Version="14.3.0" />
-    <PackageVersion Include="NSwag.MSBuild" Version="14.3.0" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.2" />
-    <PackageVersion Include="xunit.v3" Version="2.0.1" />
+    <PackageVersion Include="NSwag.AspNetCore" Version="14.4.0" />
+    <PackageVersion Include="NSwag.MSBuild" Version="14.4.0" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.1" />
+    <PackageVersion Include="xunit.v3" Version="2.0.3" />
   </ItemGroup>
   <ItemGroup>
     <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />

--- a/samples/AzureADB2CAuth/auth-backend/src/Dressca.Web/dressca-api.json
+++ b/samples/AzureADB2CAuth/auth-backend/src/Dressca.Web/dressca-api.json
@@ -1,5 +1,5 @@
 {
-  "x-generator": "NSwag v14.3.0.0 (NJsonSchema v11.2.0.0 (Newtonsoft.Json v13.0.0.0))",
+  "x-generator": "NSwag v14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))",
   "openapi": "3.0.0",
   "info": {
     "title": "Azure AD B2C ユーザー認証",


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## この Pull request で実施したこと

以下のパッケージを最新の.NET 8系に更新しました。
- Microsoft.AspNetCore.Authentication.JwtBearer 8.0.14 -> 8.0.17
- Microsoft.AspNetCore.Mvc.NewtonsoftJson 8.0.14 -> 8.0.17
- Microsoft.AspNetCore.Mvc.Testing 8.0.14 -> 8.0.17
- Microsoft.AspNetCore.SpaProxy 8.0.14 -> 8.0.17
- Microsoft.Identity.Web 3.8.2 -> 3.9.3
- Microsoft.NET.Test.Sdk 17.13.0 -> 17.14.1 
- NSwag.AspNetCore 14.3.0 -> 14.4.0 
- NSwag.MSBuild 14.3.0 -> 14.4.0 
- xunit.runner.visualstudio 3.0.2 -> 3.1.1
- xunit.v3 2.0.1 -> 2.0.3

※NSwag系のパッケージを更新後、API定義書を再生成し、差分がバージョン番号のみであることを確認済みです。

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

なし
<!-- I want to review in Japanese. -->