### PR TITLE
コードスニペットで拡張子にハイフンを含むファイルを表示できない不具合を修正

### DIFF
--- a/documents/hooks/github_markdown_fetcher.py
+++ b/documents/hooks/github_markdown_fetcher.py
@@ -27,7 +27,7 @@ def replacer(match):
 def on_page_markdown(markdown, **kwargs):
   return re.sub(
     re.compile(
-      r'^(?P<spacing>[ ]*)https://github.com/(?P<user>[\w/\-]+)/blob/(?P<filename>[\w\d\-/\.]+)\.(?P<extension>\w+)(#L(?P<begin>\d+)(-L(?P<end>\d+))?)?$',
+      r'^(?P<spacing>[ ]*)https://github.com/(?P<user>[\w/\-]+)/blob/(?P<filename>[\w\d\-/\.]+)\.(?P<extension>[\w-]+)(#L(?P<begin>\d+)(-L(?P<end>\d+))?)?$',
       re.MULTILINE,
     ),
     replacer,


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## この Pull request で実施したこと

- 現行のドキュメントには該当箇所がないため、ローカルで下記の拡張子にハイフンを含むファイルのコードスニペットが正しく表示されることを確認しました。

https://github.com/AlesInfiny/maris/blob/main/maris.code-workspace

<img width="929" height="518" alt="image" src="https://github.com/user-attachments/assets/5e0ca024-b07b-4fe4-b675-ba497d5592e3" />

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

なし

<!-- I want to review in Japanese. -->