### PR TITLE
Dresscaのパッケージバージョンを 8.0.18 に更新

### DIFF
--- a/samples/Dressca/dressca-backend/Directory.Packages.props
+++ b/samples/Dressca/dressca-backend/Directory.Packages.props
@@ -1,14 +1,14 @@
 <Project>
   <ItemGroup>
     <PackageVersion Include="Maris.Logging.Testing" Version="1.1.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.16" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.16" />
-    <PackageVersion Include="Microsoft.AspNetCore.SpaProxy" Version="8.0.16" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="8.0.17" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.17" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.17" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.18" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.18" />
+    <PackageVersion Include="Microsoft.AspNetCore.SpaProxy" Version="8.0.18" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="8.0.18" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.18" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.18" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.16" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.18" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="8.10.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## この Pull request で実施したこと

`Directory.Packages.props` ファイルにおいて、以下のパッケージのバージョンを 8.0.16 から 8.0.18 に更新しました:
- `Microsoft.AspNetCore.Mvc.Testing`
- `Microsoft.AspNetCore.Mvc.NewtonsoftJson`
- `Microsoft.AspNetCore.SpaProxy`
- `Microsoft.EntityFrameworkCore`
- `Microsoft.EntityFrameworkCore.Design`
- `Microsoft.EntityFrameworkCore.SqlServer`
- `Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore`

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

なし

<!-- I want to review in Japanese. -->