### PR TITLE
Azure AD B2Cサンプルのnugetパッケージ更新

### DIFF
--- a/samples/AzureADB2CAuth/auth-backend/Directory.Packages.props
+++ b/samples/AzureADB2CAuth/auth-backend/Directory.Packages.props
@@ -1,18 +1,18 @@
 ﻿<Project>
   <ItemGroup>
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.17" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.17" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.17" />
-    <PackageVersion Include="Microsoft.AspNetCore.SpaProxy" Version="8.0.17" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.18" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.18" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.18" />
+    <PackageVersion Include="Microsoft.AspNetCore.SpaProxy" Version="8.0.18" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
-    <PackageVersion Include="Microsoft.Identity.Web" Version="3.9.3" />
+    <PackageVersion Include="Microsoft.Identity.Web" Version="3.11.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.14.2" />
     <PackageVersion Include="NSwag.AspNetCore" Version="14.4.0" />
     <PackageVersion Include="NSwag.MSBuild" Version="14.4.0" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.1" />
-    <PackageVersion Include="xunit.v3" Version="2.0.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.3" />
+    <PackageVersion Include="xunit.v3" Version="3.0.0" />
   </ItemGroup>
   <ItemGroup>
     <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## この Pull request で実施したこと

`Microsoft.AspNetCore.Authentication.JwtBearer`, `Microsoft.AspNetCore.Mvc.NewtonsoftJson`, `Microsoft.AspNetCore.Mvc.Testing`, `Microsoft.AspNetCore.SpaProxy` のバージョンを 8.0.17 から 8.0.18 に更新しました。 `Microsoft.Identity.Web` のバージョンを 3.9.3 から 3.11.0 に更新しました。 `xunit.runner.visualstudio` のバージョンを 3.1.1 から 3.1.3 に、`xunit.v3` のバージョンを 2.0.3 から 3.0.0 に更新しました。

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

なし

<!-- I want to review in Japanese. -->