### PR TITLE
CI で使用する Node.js のバージョンを LTS バージョンに固定する

### DIFF
--- a/.github/workflows/lint-documents/action.yml
+++ b/.github/workflows/lint-documents/action.yml
@@ -7,7 +7,8 @@ runs:
     - name: Node.js のセットアップ
       uses: actions/setup-node@v4
       with:
-        node-version: 18
+        node-version: lts/*
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     - name: npm パッケージのインストール
       shell: bash

--- a/.github/workflows/samples-azure-ad-b2c-auth-ci.yml
+++ b/.github/workflows/samples-azure-ad-b2c-auth-ci.yml
@@ -24,10 +24,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       NO_COLOR: "1"  # 文字化け防止のためカラーコードを出力しない
-    strategy:
-      matrix:
-        node-version: [20.x]
-
     defaults:
       run:
         working-directory: ${{ env.FRONTEND_WORKING_DIRECTORY }}
@@ -37,10 +33,11 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js Use Node.js LTS
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: lts/*
+          # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
       - uses: actions/cache@v4
         id: node_modules_cache_id

--- a/.github/workflows/samples-dressca-admin-frontend.ci.yml
+++ b/.github/workflows/samples-dressca-admin-frontend.ci.yml
@@ -24,18 +24,13 @@ jobs:
     runs-on: ubuntu-latest
     env:
       NO_COLOR: "1"  # 文字化け防止のためカラーコードを出力しない
-    strategy:
-      matrix:
-        node-version: [20.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-
     steps:
       - uses: actions/checkout@v5
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js LTS
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
-
+          node-version: lts/*
+          # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
       - uses: actions/cache@v4
         id: node_modules_cache_id
         env:

--- a/.github/workflows/samples-dressca-consumer-frontend.ci.yml
+++ b/.github/workflows/samples-dressca-consumer-frontend.ci.yml
@@ -24,18 +24,13 @@ jobs:
     runs-on: ubuntu-latest
     env:
       NO_COLOR: "1"  # 文字化け防止のためカラーコードを出力しない
-    strategy:
-      matrix:
-        node-version: [20.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-
     steps:
       - uses: actions/checkout@v5
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js LTS
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
-
+          node-version: lts/*
+          # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
       - uses: actions/cache@v4
         id: node_modules_cache_id
         env:


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## この Pull request で実施したこと

各 CI ワークフローで使用する Node.js のバージョンを LTS バージョンに固定しました。
strategy と matrix の指定により特に複数パターンでの実行を行っていないことを検知したため、不要な設定を削除しました。

### 確認したこと
ドキュメントのビルドにおいて、Node 18 系を使用していたことに起因する警告が表示されなくなったtことを確認しました。
admin、consumer、azureadb2cサンプルにおいて、ワークフローのログを確認し、
LTS バージョンが使用されていることと、他のアクション中などで不審な警告が出ていないことを確認しました。

```console
Environment details
  node: v22.18.0
  npm: 10.9.3
  yarn: 1.22.22
```
## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク
下記のドキュメントに記載の通り、 LTS バージョンを指定するエイリアスが利用できます。
https://github.com/actions/setup-node?tab=readme-ov-file#supported-version-syntax

Maia 側は下記で対応済みです。
- https://github.com/AlesInfiny/maia/pull/2907

<!-- I want to review in Japanese. -->