### PR TITLE
xunit.runner.visualstudio 3.1.3 > 3.1.5, xunit.v3 3.0.0 >3.1.0 に更新

### DIFF
--- a/samples/ConsoleAppWithDI/solution/Directory.Packages.props
+++ b/samples/ConsoleAppWithDI/solution/Directory.Packages.props
@@ -10,8 +10,8 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.14.2" />
     <PackageVersion Include="Moq" Version="4.20.72" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.3" />
-    <PackageVersion Include="xunit.v3" Version="3.0.0" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageVersion Include="xunit.v3" Version="3.1.0" />
   </ItemGroup>
   <ItemGroup>
     <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />

--- a/samples/Dressca/dressca-backend/Directory.Packages.props
+++ b/samples/Dressca/dressca-backend/Directory.Packages.props
@@ -16,8 +16,8 @@
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="NSwag.AspNetCore" Version="14.4.0" />
     <PackageVersion Include="NSwag.MSBuild" Version="14.4.0" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.3" />
-    <PackageVersion Include="xunit.v3" Version="3.0.0" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageVersion Include="xunit.v3" Version="3.1.0" />
   </ItemGroup>
   <ItemGroup>
     <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## この Pull request で実施したこと

`xunit.runner.visualstudio` を 3.1.3 から 3.1.5 に更新し、`xunit.v3` を 3.0.0 から 3.1.0 に更新しました。
他のパッケージバージョンには変更はありません。

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

なし

<!-- I want to review in Japanese. -->