### PR TITLE
マイグレーションに利用できるツールから.NET Upgrade Assistantを削除する

### DIFF
--- a/documents/contents/guidebooks/migration/dotnetfw-risk/migration-to-dotnet.md
+++ b/documents/contents/guidebooks/migration/dotnetfw-risk/migration-to-dotnet.md
@@ -25,7 +25,7 @@ description: .NET Framework にとどまり続けることで起こりうる リ
 ### 書き換えが必要な .NET Framework の機能 {#dotnetfw-function-to-rewrite}
 
 以下の .NET Framework 機能は、.NET では廃止または非常に使用しづらいため、.NET の機能へ書き換える必要があります。
-なお、前述のとおり、どの機能においても移行法は手作業でのソースコード書き換えとなります。
+なお、前述のとおり、どの機能においても移行方法は手作業でのソースコード書き換えとなります。
 
 #### ASP.NET Web Forms ( 廃止 ) {#aspnet-web-forms}
 


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## この Pull request で実施したこと

- ドキュメントから .NET Upgrade Assistant に関する記述を削除しました。
- .NET Upgrade Assistant が非推奨になった旨の note を追加しました。

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

[マイグレーションに利用できるツールから.NET Upgrade Assistantを削除する · Issue #3689 · AlesInfiny/maris](https://github.com/AlesInfiny/maris/issues/3689)

<!-- I want to review in Japanese. -->