### PR TITLE
開発環境で SignalR 通信ログを出力するように変更し、ログレベルを調整する

### DIFF
--- a/samples/DresscaCMS/src/DresscaCMS.Web/appsettings.Development.json
+++ b/samples/DresscaCMS/src/DresscaCMS.Web/appsettings.Development.json
@@ -3,7 +3,9 @@
     "LogLevel": {
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning",
-      "Microsoft.AspNetCore.HttpLogging": "Information",
+      "Microsoft.AspNetCore.HttpLogging": "Warning",
+      "Microsoft.AspNetCore.SignalR": "Information",
+      "Microsoft.AspNetCore.Http.Connections": "Information",
       "DresscaCMS": "Debug"
     }
   },


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## この Pull request で実施したこと
- 開発環境で SignalR 通信ログを出力するように変更しました。
- ログレベルについて、開発環境では HTTP通信⇒Warning、SignalR⇒Informationに設定しました。
    - コンソールへの出力量が煩わしくないレベルをデフォルトの設定値として採用しています。

## この Pull request では実施していないこと

ガイドについては下記の PR で更新いたします。
- https://github.com/AlesInfiny/maris/pull/4139

## Issues や Discussions 、関連する Web サイトなどへのリンク

関連する Issues や Discussion へのリンクを記載します。
また、このプルリクエストを作成するにあたり参照した資料へのリンクを記載します。

<!-- I want to review in Japanese. -->