### PR TITLE
Dressca CMS を dependabot の対象にする

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -86,6 +86,12 @@ updates:
         update-types:
           - "minor"
           - "patch"
+      maris-packages:
+        patterns:
+          - "Maris*"
+        update-types:
+          - "minor"
+          - "patch"
     ignore:
       - dependency-name: "Microsoft.AspNetCore*"
         versions: ["9.*", "11.*"]
@@ -116,6 +122,12 @@ updates:
       xunit-packages:
         patterns:
           - "xunit*"
+        update-types:
+          - "minor"
+          - "patch"
+      maris-packages:
+        patterns:
+          - "Maris*"
         update-types:
           - "minor"
           - "patch"
@@ -170,6 +182,12 @@ updates:
         update-types:
           - "minor"
           - "patch"
+      maris-packages:
+        patterns:
+          - "Maris*"
+        update-types:
+          - "minor"
+          - "patch"
     ignore:
       - dependency-name: "Microsoft.AspNetCore*"
         versions: ["9.*", "11.*"]
@@ -205,6 +223,12 @@ updates:
       xunit-packages:
         patterns:
           - "xunit*"
+        update-types:
+          - "minor"
+          - "patch"
+      maris-packages:
+        patterns:
+          - "Maris*"
         update-types:
           - "minor"
           - "patch"


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## この Pull request で実施したこと

- Dressca-CMS のパッケージ情報を dependabot の監視対象に設定しました。
    - グループ分けは既存の設定を踏襲しました。
    - FluentUI 関連は 1グループにまとめました。
- Maris 関連のパッケージ情報を1グループにまとめました。

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

なし

<!-- I want to review in Japanese. -->