### PR TITLE
ZIP圧縮対象フォルダ直下の隠しファイルが含まれない問題を修正

### DIFF
--- a/.github/workflows/compress-sample-source/action.yml
+++ b/.github/workflows/compress-sample-source/action.yml
@@ -12,22 +12,22 @@ runs:
       shell: bash
       run: |
         cd samples/Dressca
-        zip -r ${GITHUB_WORKSPACE}/${{ inputs.compressed-source-path }}/dressca.zip *
+        zip -r ${GITHUB_WORKSPACE}/${{ inputs.compressed-source-path }}/dressca.zip .
 
     - name: console-app-with-di.zip の作成
       shell: bash
       run: |
         cd samples/ConsoleAppWithDI
-        zip -r  ${GITHUB_WORKSPACE}/${{ inputs.compressed-source-path }}/console-app-with-di.zip *
+        zip -r  ${GITHUB_WORKSPACE}/${{ inputs.compressed-source-path }}/console-app-with-di.zip .
 
     - name: azure-ad-b2c-auth.zip の作成
       shell: bash
       run: |
         cd samples/AzureADB2CAuth
-        zip -r ${GITHUB_WORKSPACE}/${{ inputs.compressed-source-path }}/azure-ad-b2c-auth.zip *
+        zip -r ${GITHUB_WORKSPACE}/${{ inputs.compressed-source-path }}/azure-ad-b2c-auth.zip .
 
     - name: dressca-cms.zip の作成
       shell: bash
       run: |
         cd samples/DresscaCMS
-        zip -r ${GITHUB_WORKSPACE}/${{ inputs.compressed-source-path }}/dressca-cms.zip *
+        zip -r ${GITHUB_WORKSPACE}/${{ inputs.compressed-source-path }}/dressca-cms.zip .


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## この Pull request で実施したこと

- ZIP 圧縮対象フォルダ直下のドット始まりの隠しファイルが含まれない問題を修正しました。
- dressca-cms および console-app-with-di 直下の .gitignore 等の隠しファイルが正しく zip に含まれるようになりました。

### 実行結果
- https://github.com/AlesInfiny/maris/actions/runs/20517142990
手動実行の出物からdressca-cms および console-app-with-di 直下の .gitignore 等の隠しファイルが正しく zip に含まれるようになったことを確認しました。

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

なし

<!-- I want to review in Japanese. -->