### PR TITLE
リソースファイルの公開範囲について設定基準を追記する

### DIFF
--- a/documents/contents/guidebooks/how-to-develop/csr/dotnet/project-settings.md
+++ b/documents/contents/guidebooks/how-to-develop/csr/dotnet/project-settings.md
@@ -376,7 +376,7 @@ stylecop.json は、各プロジェクトのルートフォルダーにあるか
 例外メッセージやログメッセージなど、プロジェクト内で使用するメッセージは、すべてこのリソースファイルに集約して管理します。
 
 リソースファイルの作成は、 Visual Studio を用いるのが最も簡単です。
-詳細な手順は「 [.NET アプリ用のリソース ファイルを作成する :material-open-in-new:](https://learn.microsoft.com/ja-jp/dotnet/core/extensions/create-resource-files){ target=_blank } 」を参照してください。
+詳細な手順は「 [.NET アプリ用のリソース ファイルを作成する :material-open-in-new:](https://learn.microsoft.com/ja-jp/dotnet/core/extensions/create-resource-files){ target=_blank }」を参照してください。
 
 Visual Studio を用いてリソースファイルを作成すると、リソースファイルに定義したメッセージを取得するコードが自動生成されます。
 


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## この Pull request で実施したこと

`documents\contents\guidebooks\how-to-develop\csr\dotnet\project-settings.md#add-message-resource` について、リソースを ValidationAttribute や DisplayAttribute で使う場合に public にする旨を追記しました。

また、以下の文言は後述のコラムの内容と矛盾しているため削除しました。

> 同じメッセージが複数のプロジェクトで使われる場合も、プロジェクトごとにリソースを管理しましょう。 

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

#4259 

<!-- I want to review in Japanese. -->