### PR TITLE
External ID サンプルを dependabot の監視対象にする

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -250,7 +250,7 @@ updates:
     commit-message:
       prefix: "npm-external-id-frontend"
     labels:
-      - "target: EntraID External ID"
+      - "target: Entra ID External ID"
       - "npm"
       - "dependencies"
 
@@ -262,7 +262,7 @@ updates:
     commit-message:
       prefix: "nuget-external-id-backend"
     labels:
-      - "target: EntraID External ID"
+      - "target: Entra ID External ID"
       - "nuget"
       - "dependencies"
     groups:


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## この Pull request で実施したこと

External ID サンプルを dependabot の監視対象にしました。
npm と nuget の両方について設定しました。
設定内容は AzureADB2C サンプルに準拠し、名称とラベルのみ変更しています。

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

なし

<!-- I want to review in Japanese. -->