### PR TITLE
プレリリースバージョンの Immutable Release でアセットの添付ができるようにする

### DIFF
--- a/.github/workflows/build-and-release-documents.yml
+++ b/.github/workflows/build-and-release-documents.yml
@@ -88,6 +88,7 @@ jobs:
           files: ${{ env.DOCUMENT_ARTIFACTS_FILENAME }}
           generate_release_notes: true
           prerelease: ${{ needs.build.outputs.is_pre_release }}
+          draft: ${{ needs.build.outputs.is_pre_release }}
 
   release-documents:
     name: ドキュメントのリリース


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## この Pull request で実施したこと

- Immutable Release を有効にしている場合にプレリリースバージョンでアセットの添付に失敗する現象を回避するため、`draft : true` を宣言するように変更しました。

>https://github.com/softprops/action-gh-release?tab=readme-ov-file#inputs
>On an immutable-release repository, use draft: true for prereleases that upload assets, then publish that draft later 

## この Pull request では実施していないこと

ローカルで動作確認することが難しいため、次回のBetaリリース時に想定通りの挙動をするか確認します。

## Issues や Discussions 、関連する Web サイトなどへのリンク

なし

<!-- I want to review in Japanese. -->