### PR TITLE
Dressca のラベルとフォームコントロールの未関連付けの警告に対応

### DIFF
--- a/samples/Dressca/dressca-frontend/consumer/src/components/basket/BasketItem.vue
+++ b/samples/Dressca/dressca-frontend/consumer/src/components/basket/BasketItem.vue
@@ -66,8 +66,9 @@ const remove = () => {
     <div class="grid grid-cols-1 lg:grid-cols-3">
       <div class="grid place-items-end lg:col-span-2 lg:flex lg:flex-row lg:items-center">
         <div class="mt-2 mr-2 ml-2 basis-3/5 text-right lg:pr-10">
-          <label>
+          <label :for="`quantity-input-${item.catalogItemId}`">
             <input
+              :id="`quantity-input-${item.catalogItemId}`"
               v-model.number="quantity"
               type="number"
               min="1"

--- a/samples/Dressca/dressca-frontend/consumer/src/views/catalog/CatalogView.vue
+++ b/samples/Dressca/dressca-frontend/consumer/src/views/catalog/CatalogView.vue
@@ -118,24 +118,20 @@ watch([selectedCategory, selectedBrand], async () => {
       <div class="flex justify-center">
         <div class="my-4 grid grid-cols-1 text-lg lg:grid-cols-2 lg:gap-24">
           <div>
-            <label class="mr-2 font-bold">
-              カテゴリ
-              <select v-model="selectedCategory" class="w-48 border-2">
-                <option v-for="category in getCategories" :key="category.id" :value="category.id">
-                  {{ category.name }}
-                </option>
-              </select>
-            </label>
+            <label for="category-select" class="mr-2 font-bold"> カテゴリ </label>
+            <select id="category-select" v-model="selectedCategory" class="w-48 border-2">
+              <option v-for="category in getCategories" :key="category.id" :value="category.id">
+                {{ category.name }}
+              </option>
+            </select>
           </div>
           <div class="mt-2 lg:mt-0">
-            <label class="mr-2 font-bold">
-              ブランド
-              <select v-model="selectedBrand" class="w-48 border-2">
-                <option v-for="brand in getBrands" :key="brand.id" :value="brand.id">
-                  {{ brand.name }}
-                </option>
-              </select>
-            </label>
+            <label for="brand-select" class="mr-2 font-bold"> ブランド </label>
+            <select id="brand-select" v-model="selectedBrand" class="w-48 border-2">
+              <option v-for="brand in getBrands" :key="brand.id" :value="brand.id">
+                {{ brand.name }}
+              </option>
+            </select>
           </div>
         </div>
       </div>


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## この Pull request で実施したこと

- 下記の箇所についてラベルと入力フォームの関連付けを付与しました。
    - アイテム一覧画面のカテゴリとブランドのセレクトボックス
    - 買い物かごアイテムコンポーネントの数量
- 該当箇所について、開発者コンソール上に 「No label associated with a form field」 が出力されなくなります。

## この Pull request では実施していないこと

今回のスコープは警告への対処とし、一般化された根本対応は下記の方法で実施します。
おそらくすべてのコンポーネントにやっておいたほうが安全なので今回は見送ります。
- https://github.com/AlesInfiny/maris/issues/4952

## Issues や Discussions 、関連する Web サイトなどへのリンク

なし

<!-- I want to review in Japanese. -->