### PR TITLE
openapi-generator-cli をアップデートし、推移的に依存するパッケージに脆弱性パッチを適用

### DIFF
--- a/samples/AzureADB2CAuth/auth-frontend/app/package.json
+++ b/samples/AzureADB2CAuth/auth-frontend/app/package.json
@@ -27,7 +27,7 @@
     "vue": "3.5.30"
   },
   "devDependencies": {
-    "@openapitools/openapi-generator-cli": "2.30.2",
+    "@openapitools/openapi-generator-cli": "2.31.0",
     "@tsconfig/node24": "24.0.4",
     "@types/jsdom": "28.0.0",
     "@types/node": "25.5.0",

--- a/samples/AzureADB2CAuth/auth-frontend/package-lock.json
+++ b/samples/AzureADB2CAuth/auth-frontend/package-lock.json
@@ -24,7 +24,7 @@
         "vue": "3.5.30"
       },
       "devDependencies": {
-        "@openapitools/openapi-generator-cli": "2.30.2",
+        "@openapitools/openapi-generator-cli": "2.31.0",
         "@tsconfig/node24": "24.0.4",
         "@types/jsdom": "28.0.0",
         "@types/node": "25.5.0",
@@ -592,9 +592,9 @@
       }
     },
     "node_modules/@borewit/text-codec": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.1.tgz",
-      "integrity": "sha512-k7vvKPbf7J2fZ5klGRD9AeKfUvojuZIQ3BT5u7Jfv+puwXkUBUT5PVyMDfJZpy30CBDXGMgw7fguK/lpOMBvgw==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+      "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1841,13 +1841,13 @@
       }
     },
     "node_modules/@nestjs/common": {
-      "version": "11.1.16",
-      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.16.tgz",
-      "integrity": "sha512-JSIeW+USuMJkkcNbiOdcPkVCeI3TSnXstIVEPpp3HiaKnPRuSbUUKm9TY9o/XpIcPHWUOQItAtC5BiAwFdVITQ==",
+      "version": "11.1.17",
+      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.17.tgz",
+      "integrity": "sha512-hLODw5Abp8OQgA+mUO4tHou4krKgDtUcM9j5Ihxncst9XeyxYBTt2bwZm4e4EQr5E352S4Fyy6V3iFx9ggxKAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "file-type": "21.3.0",
+        "file-type": "21.3.2",
         "iterare": "1.2.1",
         "load-esm": "1.0.3",
         "tslib": "2.8.1",
@@ -1873,9 +1873,9 @@
       }
     },
     "node_modules/@nestjs/core": {
-      "version": "11.1.16",
-      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-11.1.16.tgz",
-      "integrity": "sha512-tXWXyCiqWthelJjrE0KLFjf0O98VEt+WPVx5CrqCf+059kIxJ8y1Vw7Cy7N4fwQafWNrmFL2AfN87DDMbVAY0w==",
+      "version": "11.1.17",
+      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-11.1.17.tgz",
+      "integrity": "sha512-lD5mAYekTTurF3vDaa8C2OKPnjiz4tsfxIc5XlcSUzOhkwWf6Ay3HKvt6FmvuWQam6uIIHX52Clg+e6tAvf/cg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -2027,17 +2027,17 @@
       "license": "MIT"
     },
     "node_modules/@openapitools/openapi-generator-cli": {
-      "version": "2.30.2",
-      "resolved": "https://registry.npmjs.org/@openapitools/openapi-generator-cli/-/openapi-generator-cli-2.30.2.tgz",
-      "integrity": "sha512-rGgLrY88f7/eTBc2wmehhcqQq7/1wEkNQUhvk1NF0nh/bCGGGRfzN6O4U2VHsREtshUT+IUaRoJwq4UeDrRXZQ==",
+      "version": "2.31.0",
+      "resolved": "https://registry.npmjs.org/@openapitools/openapi-generator-cli/-/openapi-generator-cli-2.31.0.tgz",
+      "integrity": "sha512-sd+VIr5vx4PSknJLzh9thyRC8pw0r8ayCB4xH4G383BRClc3uFxIIz5EkBVndOumRsvPDip4wbszf5RRtxbmGA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/select": "1.3.3",
         "@nestjs/axios": "4.0.1",
-        "@nestjs/common": "11.1.16",
-        "@nestjs/core": "11.1.16",
+        "@nestjs/common": "11.1.17",
+        "@nestjs/core": "11.1.17",
         "@nuxtjs/opencollective": "0.3.2",
         "axios": "^1.13.6",
         "chalk": "4.1.2",
@@ -4990,9 +4990,9 @@
       }
     },
     "node_modules/file-type": {
-      "version": "21.3.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.0.tgz",
-      "integrity": "sha512-8kPJMIGz1Yt/aPEwOsrR97ZyZaD1Iqm8PClb1nYFclUCkBi0Ma5IsYNQzvSFS9ib51lWyIw5mIT9rWzI/xjpzA==",
+      "version": "21.3.2",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.2.tgz",
+      "integrity": "sha512-DLkUvGwep3poOV2wpzbHCOnSKGk1LzyXTv+aHFgN2VFl96wnp8YA9YjO2qPzg5PuL8q/SW9Pdi6WTkYOIh995w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5497,7 +5497,8 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -7401,9 +7402,9 @@
       }
     },
     "node_modules/strtok3": {
-      "version": "10.3.4",
-      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.4.tgz",
-      "integrity": "sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg==",
+      "version": "10.3.5",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
+      "integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/samples/Dressca/dressca-frontend/admin/package.json
+++ b/samples/Dressca/dressca-frontend/admin/package.json
@@ -38,7 +38,7 @@
     "yup": "1.7.1"
   },
   "devDependencies": {
-    "@openapitools/openapi-generator-cli": "2.30.2",
+    "@openapitools/openapi-generator-cli": "2.31.0",
     "@pinia/testing": "1.0.3",
     "@tailwindcss/vite": "4.2.1",
     "@tsconfig/node24": "24.0.4",

--- a/samples/Dressca/dressca-frontend/consumer/package.json
+++ b/samples/Dressca/dressca-frontend/consumer/package.json
@@ -38,7 +38,7 @@
     "yup": "1.7.1"
   },
   "devDependencies": {
-    "@openapitools/openapi-generator-cli": "2.30.2",
+    "@openapitools/openapi-generator-cli": "2.31.0",
     "@pinia/testing": "1.0.3",
     "@tailwindcss/vite": "4.2.1",
     "@tsconfig/node24": "24.0.4",

--- a/samples/Dressca/dressca-frontend/package-lock.json
+++ b/samples/Dressca/dressca-frontend/package-lock.json
@@ -30,7 +30,7 @@
         "yup": "1.7.1"
       },
       "devDependencies": {
-        "@openapitools/openapi-generator-cli": "2.30.2",
+        "@openapitools/openapi-generator-cli": "2.31.0",
         "@pinia/testing": "1.0.3",
         "@tailwindcss/vite": "4.2.1",
         "@tsconfig/node24": "24.0.4",
@@ -370,7 +370,7 @@
         "yup": "1.7.1"
       },
       "devDependencies": {
-        "@openapitools/openapi-generator-cli": "2.30.2",
+        "@openapitools/openapi-generator-cli": "2.31.0",
         "@pinia/testing": "1.0.3",
         "@tailwindcss/vite": "4.2.1",
         "@tsconfig/node24": "24.0.4",
@@ -1317,9 +1317,9 @@
       }
     },
     "node_modules/@borewit/text-codec": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.1.tgz",
-      "integrity": "sha512-k7vvKPbf7J2fZ5klGRD9AeKfUvojuZIQ3BT5u7Jfv+puwXkUBUT5PVyMDfJZpy30CBDXGMgw7fguK/lpOMBvgw==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+      "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -2777,13 +2777,13 @@
       }
     },
     "node_modules/@nestjs/common": {
-      "version": "11.1.16",
-      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.16.tgz",
-      "integrity": "sha512-JSIeW+USuMJkkcNbiOdcPkVCeI3TSnXstIVEPpp3HiaKnPRuSbUUKm9TY9o/XpIcPHWUOQItAtC5BiAwFdVITQ==",
+      "version": "11.1.17",
+      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.17.tgz",
+      "integrity": "sha512-hLODw5Abp8OQgA+mUO4tHou4krKgDtUcM9j5Ihxncst9XeyxYBTt2bwZm4e4EQr5E352S4Fyy6V3iFx9ggxKAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "file-type": "21.3.0",
+        "file-type": "21.3.2",
         "iterare": "1.2.1",
         "load-esm": "1.0.3",
         "tslib": "2.8.1",
@@ -2809,9 +2809,9 @@
       }
     },
     "node_modules/@nestjs/core": {
-      "version": "11.1.16",
-      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-11.1.16.tgz",
-      "integrity": "sha512-tXWXyCiqWthelJjrE0KLFjf0O98VEt+WPVx5CrqCf+059kIxJ8y1Vw7Cy7N4fwQafWNrmFL2AfN87DDMbVAY0w==",
+      "version": "11.1.17",
+      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-11.1.17.tgz",
+      "integrity": "sha512-lD5mAYekTTurF3vDaa8C2OKPnjiz4tsfxIc5XlcSUzOhkwWf6Ay3HKvt6FmvuWQam6uIIHX52Clg+e6tAvf/cg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -2956,17 +2956,17 @@
       "license": "MIT"
     },
     "node_modules/@openapitools/openapi-generator-cli": {
-      "version": "2.30.2",
-      "resolved": "https://registry.npmjs.org/@openapitools/openapi-generator-cli/-/openapi-generator-cli-2.30.2.tgz",
-      "integrity": "sha512-rGgLrY88f7/eTBc2wmehhcqQq7/1wEkNQUhvk1NF0nh/bCGGGRfzN6O4U2VHsREtshUT+IUaRoJwq4UeDrRXZQ==",
+      "version": "2.31.0",
+      "resolved": "https://registry.npmjs.org/@openapitools/openapi-generator-cli/-/openapi-generator-cli-2.31.0.tgz",
+      "integrity": "sha512-sd+VIr5vx4PSknJLzh9thyRC8pw0r8ayCB4xH4G383BRClc3uFxIIz5EkBVndOumRsvPDip4wbszf5RRtxbmGA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/select": "1.3.3",
         "@nestjs/axios": "4.0.1",
-        "@nestjs/common": "11.1.16",
-        "@nestjs/core": "11.1.16",
+        "@nestjs/common": "11.1.17",
+        "@nestjs/core": "11.1.17",
         "@nuxtjs/opencollective": "0.3.2",
         "axios": "^1.13.6",
         "chalk": "4.1.2",
@@ -7012,9 +7012,9 @@
       }
     },
     "node_modules/file-type": {
-      "version": "21.3.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.0.tgz",
-      "integrity": "sha512-8kPJMIGz1Yt/aPEwOsrR97ZyZaD1Iqm8PClb1nYFclUCkBi0Ma5IsYNQzvSFS9ib51lWyIw5mIT9rWzI/xjpzA==",
+      "version": "21.3.2",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.2.tgz",
+      "integrity": "sha512-DLkUvGwep3poOV2wpzbHCOnSKGk1LzyXTv+aHFgN2VFl96wnp8YA9YjO2qPzg5PuL8q/SW9Pdi6WTkYOIh995w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10996,9 +10996,9 @@
       }
     },
     "node_modules/strtok3": {
-      "version": "10.3.4",
-      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.4.tgz",
-      "integrity": "sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg==",
+      "version": "10.3.5",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
+      "integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/samples/ExternalIDSampleForSPA/auth-frontend/app/package.json
+++ b/samples/ExternalIDSampleForSPA/auth-frontend/app/package.json
@@ -28,7 +28,7 @@
     "vue": "3.5.30"
   },
   "devDependencies": {
-    "@openapitools/openapi-generator-cli": "2.30.2",
+    "@openapitools/openapi-generator-cli": "2.31.0",
     "@pinia/testing": "1.0.3",
     "@tsconfig/node24": "24.0.4",
     "@types/jsdom": "28.0.0",

--- a/samples/ExternalIDSampleForSPA/auth-frontend/package-lock.json
+++ b/samples/ExternalIDSampleForSPA/auth-frontend/package-lock.json
@@ -24,7 +24,7 @@
         "vue": "3.5.30"
       },
       "devDependencies": {
-        "@openapitools/openapi-generator-cli": "2.30.2",
+        "@openapitools/openapi-generator-cli": "2.31.0",
         "@pinia/testing": "1.0.3",
         "@tsconfig/node24": "24.0.4",
         "@types/jsdom": "28.0.0",
@@ -889,9 +889,9 @@
       }
     },
     "node_modules/@borewit/text-codec": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.1.tgz",
-      "integrity": "sha512-k7vvKPbf7J2fZ5klGRD9AeKfUvojuZIQ3BT5u7Jfv+puwXkUBUT5PVyMDfJZpy30CBDXGMgw7fguK/lpOMBvgw==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+      "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -2131,13 +2131,13 @@
       }
     },
     "node_modules/@nestjs/common": {
-      "version": "11.1.16",
-      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.16.tgz",
-      "integrity": "sha512-JSIeW+USuMJkkcNbiOdcPkVCeI3TSnXstIVEPpp3HiaKnPRuSbUUKm9TY9o/XpIcPHWUOQItAtC5BiAwFdVITQ==",
+      "version": "11.1.17",
+      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.17.tgz",
+      "integrity": "sha512-hLODw5Abp8OQgA+mUO4tHou4krKgDtUcM9j5Ihxncst9XeyxYBTt2bwZm4e4EQr5E352S4Fyy6V3iFx9ggxKAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "file-type": "21.3.0",
+        "file-type": "21.3.2",
         "iterare": "1.2.1",
         "load-esm": "1.0.3",
         "tslib": "2.8.1",
@@ -2163,9 +2163,9 @@
       }
     },
     "node_modules/@nestjs/core": {
-      "version": "11.1.16",
-      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-11.1.16.tgz",
-      "integrity": "sha512-tXWXyCiqWthelJjrE0KLFjf0O98VEt+WPVx5CrqCf+059kIxJ8y1Vw7Cy7N4fwQafWNrmFL2AfN87DDMbVAY0w==",
+      "version": "11.1.17",
+      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-11.1.17.tgz",
+      "integrity": "sha512-lD5mAYekTTurF3vDaa8C2OKPnjiz4tsfxIc5XlcSUzOhkwWf6Ay3HKvt6FmvuWQam6uIIHX52Clg+e6tAvf/cg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -2317,17 +2317,17 @@
       "license": "MIT"
     },
     "node_modules/@openapitools/openapi-generator-cli": {
-      "version": "2.30.2",
-      "resolved": "https://registry.npmjs.org/@openapitools/openapi-generator-cli/-/openapi-generator-cli-2.30.2.tgz",
-      "integrity": "sha512-rGgLrY88f7/eTBc2wmehhcqQq7/1wEkNQUhvk1NF0nh/bCGGGRfzN6O4U2VHsREtshUT+IUaRoJwq4UeDrRXZQ==",
+      "version": "2.31.0",
+      "resolved": "https://registry.npmjs.org/@openapitools/openapi-generator-cli/-/openapi-generator-cli-2.31.0.tgz",
+      "integrity": "sha512-sd+VIr5vx4PSknJLzh9thyRC8pw0r8ayCB4xH4G383BRClc3uFxIIz5EkBVndOumRsvPDip4wbszf5RRtxbmGA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/select": "1.3.3",
         "@nestjs/axios": "4.0.1",
-        "@nestjs/common": "11.1.16",
-        "@nestjs/core": "11.1.16",
+        "@nestjs/common": "11.1.17",
+        "@nestjs/core": "11.1.17",
         "@nuxtjs/opencollective": "0.3.2",
         "axios": "^1.13.6",
         "chalk": "4.1.2",
@@ -5181,9 +5181,9 @@
       }
     },
     "node_modules/file-type": {
-      "version": "21.3.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.0.tgz",
-      "integrity": "sha512-8kPJMIGz1Yt/aPEwOsrR97ZyZaD1Iqm8PClb1nYFclUCkBi0Ma5IsYNQzvSFS9ib51lWyIw5mIT9rWzI/xjpzA==",
+      "version": "21.3.2",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.2.tgz",
+      "integrity": "sha512-DLkUvGwep3poOV2wpzbHCOnSKGk1LzyXTv+aHFgN2VFl96wnp8YA9YjO2qPzg5PuL8q/SW9Pdi6WTkYOIh995w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5695,7 +5695,8 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -7667,9 +7668,9 @@
       }
     },
     "node_modules/strtok3": {
-      "version": "10.3.4",
-      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.4.tgz",
-      "integrity": "sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg==",
+      "version": "10.3.5",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
+      "integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## この Pull request で実施したこと

- openapi-generator-cli 2.31.0 にアップデートし、推移的に依存するパッケージに脆弱性パッチを適用しました。
    - npm install/ci で脆弱性に関する警告が出ないことを確認しました。
- npm run generate-client を各ワークスペースで実行し、生成されるコードに差分がないことを確認しました。

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

なし

<!-- I want to review in Japanese. -->