### PR TITLE
pymdown-extensions を 10.21.2 にアップデート

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 yamllint==1.38.0
 mkdocs==1.6.1
 mkdocs-material==9.7.5
-pymdown-extensions==10.21
+pymdown-extensions==10.21.2
 mkdocs-git-revision-date-localized-plugin==1.5.1
 mkdocs-minify-plugin==0.8.0
 mkdocs-rss-plugin==1.17.9


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## この Pull request で実施したこと

pymdown-extensions を 10.21.2 にアップデートしました。
pygment 2.20.0 で mkdocs のビルドが失敗する問題に対処しています。

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

クールタイム 7日間を設定しているため、 dependabot から PR は上がりません。
ドキュメントのビルドが全体に落ちており影響が大きいため、手動でアップデートします。

<!-- I want to review in Japanese. -->