### PR TITLE
DresscaCMS にヘルスチェック API を追加する

### DIFF
--- a/samples/DresscaCMS/Directory.Packages.props
+++ b/samples/DresscaCMS/Directory.Packages.props
@@ -6,6 +6,7 @@
     <PackageVersion Include="Maris.Logging.Testing" Version="2.1.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Identity" Version="2.3.9" />
     <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="10.0.5" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
     <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.14.0" />
     <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="4.14.0" />

--- a/samples/DresscaCMS/src/DresscaCMS.Announcement/DresscaCMS.Announcement.csproj
+++ b/samples/DresscaCMS/src/DresscaCMS.Announcement/DresscaCMS.Announcement.csproj
@@ -11,6 +11,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
   </ItemGroup>
 

--- a/samples/DresscaCMS/src/DresscaCMS.Announcement/Events.cs
+++ b/samples/DresscaCMS/src/DresscaCMS.Announcement/Events.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace DresscaCMS.Announcement;
+
+/// <summary>
+/// イベントIDを管理するクラスです。
+/// </summary>
+internal class Events
+{
+    /// <summary>
+    /// データベースのヘルスチェックに失敗したことを示すイベントID
+    /// </summary>
+    internal static readonly EventId FailedDatabaseHealthCheck = new(1001, nameof(FailedDatabaseHealthCheck));
+}

--- a/samples/DresscaCMS/src/DresscaCMS.Announcement/Events.cs
+++ b/samples/DresscaCMS/src/DresscaCMS.Announcement/Events.cs
@@ -5,7 +5,7 @@ namespace DresscaCMS.Announcement;
 /// <summary>
 /// イベントIDを管理するクラスです。
 /// </summary>
-internal class Events
+internal static class Events
 {
     /// <summary>
     /// データベースのヘルスチェックに失敗したことを示すイベントID

--- a/samples/DresscaCMS/src/DresscaCMS.Announcement/Infrastructures/AnnouncementDbContextHealthCheck.cs
+++ b/samples/DresscaCMS/src/DresscaCMS.Announcement/Infrastructures/AnnouncementDbContextHealthCheck.cs
@@ -43,7 +43,7 @@ internal class AnnouncementDbContextHealthCheck : IHealthCheck
                 logLevel: LogLevel.Warning,
                 exception: ex,
                 message: Messages.FailedDatabaseHealthCheck);
-            return new HealthCheckResult(context.Registration.FailureStatus, exception: ex);
+            return new HealthCheckResult(context.Registration.FailureStatus);
         }
     }
 }

--- a/samples/DresscaCMS/src/DresscaCMS.Announcement/Infrastructures/AnnouncementDbContextHealthCheck.cs
+++ b/samples/DresscaCMS/src/DresscaCMS.Announcement/Infrastructures/AnnouncementDbContextHealthCheck.cs
@@ -1,0 +1,49 @@
+﻿using DresscaCMS.Announcement.Resources;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
+
+namespace DresscaCMS.Announcement.Infrastructures;
+
+/// <summary>
+///  <see cref="AnnouncementDbContext"/> のヘルスチェックを実装します。
+/// </summary>
+internal class AnnouncementDbContextHealthCheck : IHealthCheck
+{
+    private readonly IDbContextFactory<AnnouncementDbContext> dbContextFactory;
+    private readonly ILogger<AnnouncementDbContextHealthCheck> logger;
+
+    /// <summary>
+    ///  <see cref="AnnouncementDbContextHealthCheck"/> クラスの新しいインスタンスを初期化します。
+    /// </summary>
+    /// <param name="dbContextFactory">データアクセスに使用する <see cref="IDbContextFactory{AnnouncementDbContext}"/> オブジェクト。</param>
+    /// <param name="logger">ロガー。</param>
+    public AnnouncementDbContextHealthCheck(
+        IDbContextFactory<AnnouncementDbContext> dbContextFactory,
+        ILogger<AnnouncementDbContextHealthCheck> logger)
+    {
+        this.dbContextFactory = dbContextFactory;
+        this.logger = logger;
+    }
+
+    /// <inheritdoc/>
+    public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await using var dbContext = await this.dbContextFactory.CreateDbContextAsync(cancellationToken);
+            await dbContext.Database.ExecuteSqlRawAsync("SELECT 1", cancellationToken);
+
+            return HealthCheckResult.Healthy();
+        }
+        catch (Exception ex)
+        {
+            this.logger.Log(
+                eventId: Events.FailedDatabaseHealthCheck,
+                logLevel: LogLevel.Warning,
+                exception: ex,
+                message: Messages.FailedDatabaseHealthCheck);
+            return new HealthCheckResult(context.Registration.FailureStatus, exception: ex);
+        }
+    }
+}

--- a/samples/DresscaCMS/src/DresscaCMS.Announcement/Infrastructures/HealthChecksBuilderExtensions.cs
+++ b/samples/DresscaCMS/src/DresscaCMS.Announcement/Infrastructures/HealthChecksBuilderExtensions.cs
@@ -1,0 +1,56 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using DresscaCMS.Announcement.Resources;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
+
+namespace DresscaCMS.Announcement.Infrastructures;
+
+/// <summary>
+///  <see cref="IHealthChecksBuilder"/> の拡張メソッドを提供します。
+/// </summary>
+[SuppressMessage(
+    category: "StyleCop.CSharp.ReadabilityRules",
+    checkId: "SA1101:PrefixLocalCallsWithThis",
+    Justification = "StyleCop bug. see: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3954")]
+public static class HealthChecksBuilderExtensions
+{
+    extension(IHealthChecksBuilder builder)
+    {
+        /// <summary>
+        ///  <see cref="AnnouncementDbContext"/> のヘルスチェックを追加します。
+        /// </summary>
+        /// <param name="name">ヘルスチェックの名称。</param>
+        /// <param name="failureStatus">ヘルスチェックが失敗した場合の<see cref="HealthStatus"/> 。</param>
+        /// <param name="tags">ヘルスチェックのタグ。</param>
+        /// <param name="logLevel">ログレベル。</param>
+        /// <returns><see cref="AnnouncementDbContext"/> のヘルスチェックを実装した<see cref="IHealthChecksBuilder"/>。</returns>
+        public IHealthChecksBuilder AddAnnouncementDbContextCheck(string? name = null, HealthStatus? failureStatus = default, IEnumerable<string>? tags = default, LogLevel logLevel = LogLevel.Warning)
+        {
+            return builder.AddDbContextCheck<AnnouncementDbContext>(
+            name,
+            failureStatus,
+            tags,
+            async (context, token) =>
+            {
+                try
+                {
+                    await context.Database.ExecuteSqlRawAsync("SELECT 1", token);
+                    return true;
+                }
+                catch (Exception ex)
+                {
+                    var loggerFactory = builder.Services.BuildServiceProvider().GetRequiredService<ILoggerFactory>();
+                    var logger = loggerFactory.CreateLogger("DresscaCMS.Announcement.EfInfrastructure.HealthChecksBuilderExtensions");
+                    logger.Log(
+                        eventId: Events.FailedDatabaseHealthCheck,
+                        logLevel: logLevel,
+                        exception: ex,
+                        message: Messages.FailedDatabaseHealthCheck);
+                    return false;
+                }
+            });
+        }
+    }
+}

--- a/samples/DresscaCMS/src/DresscaCMS.Announcement/Infrastructures/HealthChecksBuilderExtensions.cs
+++ b/samples/DresscaCMS/src/DresscaCMS.Announcement/Infrastructures/HealthChecksBuilderExtensions.cs
@@ -42,7 +42,7 @@ public static class HealthChecksBuilderExtensions
                 catch (Exception ex)
                 {
                     var loggerFactory = builder.Services.BuildServiceProvider().GetRequiredService<ILoggerFactory>();
-                    var logger = loggerFactory.CreateLogger("DresscaCMS.Announcement.EfInfrastructure.HealthChecksBuilderExtensions");
+                    var logger = loggerFactory.CreateLogger("DresscaCMS.Announcement.Infrastructures.HealthChecksBuilderExtensions");
                     logger.Log(
                         eventId: Events.FailedDatabaseHealthCheck,
                         logLevel: logLevel,

--- a/samples/DresscaCMS/src/DresscaCMS.Announcement/Infrastructures/HealthChecksBuilderExtensions.cs
+++ b/samples/DresscaCMS/src/DresscaCMS.Announcement/Infrastructures/HealthChecksBuilderExtensions.cs
@@ -1,9 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
-using DresscaCMS.Announcement.Resources;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
-using Microsoft.Extensions.Logging;
 
 namespace DresscaCMS.Announcement.Infrastructures;
 
@@ -24,33 +21,13 @@ public static class HealthChecksBuilderExtensions
         /// <param name="name">ヘルスチェックの名称。</param>
         /// <param name="failureStatus">ヘルスチェックが失敗した場合の<see cref="HealthStatus"/> 。</param>
         /// <param name="tags">ヘルスチェックのタグ。</param>
-        /// <param name="logLevel">ログレベル。</param>
         /// <returns><see cref="AnnouncementDbContext"/> のヘルスチェックを実装した<see cref="IHealthChecksBuilder"/>。</returns>
-        public IHealthChecksBuilder AddAnnouncementDbContextCheck(string? name = null, HealthStatus? failureStatus = default, IEnumerable<string>? tags = default, LogLevel logLevel = LogLevel.Warning)
+        public IHealthChecksBuilder AddAnnouncementDbContextCheck(string name, HealthStatus? failureStatus = default, IEnumerable<string>? tags = default)
         {
-            return builder.AddDbContextCheck<AnnouncementDbContext>(
-            name,
-            failureStatus,
-            tags,
-            async (context, token) =>
-            {
-                try
-                {
-                    await context.Database.ExecuteSqlRawAsync("SELECT 1", token);
-                    return true;
-                }
-                catch (Exception ex)
-                {
-                    var loggerFactory = builder.Services.BuildServiceProvider().GetRequiredService<ILoggerFactory>();
-                    var logger = loggerFactory.CreateLogger("DresscaCMS.Announcement.Infrastructures.HealthChecksBuilderExtensions");
-                    logger.Log(
-                        eventId: Events.FailedDatabaseHealthCheck,
-                        logLevel: logLevel,
-                        exception: ex,
-                        message: Messages.FailedDatabaseHealthCheck);
-                    return false;
-                }
-            });
+            return builder.AddCheck<AnnouncementDbContextHealthCheck>(
+                name,
+                failureStatus,
+                tags ?? []);
         }
     }
 }

--- a/samples/DresscaCMS/src/DresscaCMS.Announcement/Resources/Messages.Designer.cs
+++ b/samples/DresscaCMS/src/DresscaCMS.Announcement/Resources/Messages.Designer.cs
@@ -99,6 +99,15 @@ namespace DresscaCMS.Announcement.Resources {
         }
 
         /// <summary>
+        ///   データベースのヘルスチェックが失敗しました。 に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        internal static string FailedDatabaseHealthCheck {
+            get {
+                return ResourceManager.GetString("FailedDatabaseHealthCheck", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   {0} 接続文字列を構成から取得できません。 に類似しているローカライズされた文字列を検索します。
         /// </summary>
         internal static string NotFoundConnectionString {

--- a/samples/DresscaCMS/src/DresscaCMS.Announcement/Resources/Messages.resx
+++ b/samples/DresscaCMS/src/DresscaCMS.Announcement/Resources/Messages.resx
@@ -138,4 +138,7 @@
   <data name="ContainsInvalidLanguageCode" xml:space="preserve">
     <value>お知らせメッセージに不正な言語コードが含まれています。</value>
   </data>
+  <data name="FailedDatabaseHealthCheck" xml:space="preserve">
+    <value>データベースのヘルスチェックが失敗しました。</value>
+  </data>
 </root>

--- a/samples/DresscaCMS/src/DresscaCMS.Authentication/DresscaCMS.Authentication.csproj
+++ b/samples/DresscaCMS/src/DresscaCMS.Authentication/DresscaCMS.Authentication.csproj
@@ -11,6 +11,22 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Update="Resources\Messages.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Messages.resx</DependentUpon>
+    </Compile>
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Update="Resources\Messages.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>Messages.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/DresscaCMS/src/DresscaCMS.Authentication/DresscaCMS.Authentication.csproj
+++ b/samples/DresscaCMS/src/DresscaCMS.Authentication/DresscaCMS.Authentication.csproj
@@ -29,19 +29,4 @@
     </EmbeddedResource>
   </ItemGroup>
 
-  <ItemGroup>
-    <Compile Update="Resources\Messages.Designer.cs">
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>Messages.resx</DependentUpon>
-    </Compile>
-  </ItemGroup>
-
-  <ItemGroup>
-    <EmbeddedResource Update="Resources\Messages.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-      <LastGenOutput>Messages.Designer.cs</LastGenOutput>
-    </EmbeddedResource>
-  </ItemGroup>
-
 </Project>

--- a/samples/DresscaCMS/src/DresscaCMS.Authentication/Events.cs
+++ b/samples/DresscaCMS/src/DresscaCMS.Authentication/Events.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace DresscaCMS.Authentication;
+
+/// <summary>
+/// イベントIDを管理するクラスです。
+/// </summary>
+internal class Events
+{
+    /// <summary>
+    /// データベースのヘルスチェックに失敗したことを示すイベントID
+    /// </summary>
+    internal static readonly EventId FailedDatabaseHealthCheck = new(1001, nameof(FailedDatabaseHealthCheck));
+}

--- a/samples/DresscaCMS/src/DresscaCMS.Authentication/Events.cs
+++ b/samples/DresscaCMS/src/DresscaCMS.Authentication/Events.cs
@@ -5,7 +5,7 @@ namespace DresscaCMS.Authentication;
 /// <summary>
 /// イベントIDを管理するクラスです。
 /// </summary>
-internal class Events
+internal static class Events
 {
     /// <summary>
     /// データベースのヘルスチェックに失敗したことを示すイベントID

--- a/samples/DresscaCMS/src/DresscaCMS.Authentication/Infrastructures/AuthenticationDbContextHealthCheck.cs
+++ b/samples/DresscaCMS/src/DresscaCMS.Authentication/Infrastructures/AuthenticationDbContextHealthCheck.cs
@@ -1,0 +1,49 @@
+﻿using DresscaCMS.Authentication.Resources;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
+
+namespace DresscaCMS.Authentication.Infrastructures;
+
+/// <summary>
+///  <see cref="AuthenticationDbContext"/> のヘルスチェックを実装します。
+/// </summary>
+internal class AuthenticationDbContextHealthCheck : IHealthCheck
+{
+    private readonly IDbContextFactory<AuthenticationDbContext> dbContextFactory;
+    private readonly ILogger<AuthenticationDbContextHealthCheck> logger;
+
+    /// <summary>
+    ///  <see cref="AuthenticationDbContextHealthCheck"/> クラスの新しいインスタンスを初期化します。
+    /// </summary>
+    /// <param name="dbContextFactory">データアクセスに使用する <see cref="IDbContextFactory{AuthenticationDbContext}"/> オブジェクト。</param>
+    /// <param name="logger">ロガー。</param>
+    public AuthenticationDbContextHealthCheck(
+        IDbContextFactory<AuthenticationDbContext> dbContextFactory,
+        ILogger<AuthenticationDbContextHealthCheck> logger)
+    {
+        this.dbContextFactory = dbContextFactory;
+        this.logger = logger;
+    }
+
+    /// <inheritdoc/>
+    public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await using var dbContext = await this.dbContextFactory.CreateDbContextAsync(cancellationToken);
+            await dbContext.Database.ExecuteSqlRawAsync("SELECT 1", cancellationToken);
+
+            return HealthCheckResult.Healthy();
+        }
+        catch (Exception ex)
+        {
+            this.logger.Log(
+                eventId: Events.FailedDatabaseHealthCheck,
+                logLevel: LogLevel.Warning,
+                exception: ex,
+                message: Messages.FailedDatabaseHealthCheck);
+            return new HealthCheckResult(context.Registration.FailureStatus, exception: ex);
+        }
+    }
+}

--- a/samples/DresscaCMS/src/DresscaCMS.Authentication/Infrastructures/AuthenticationDbContextHealthCheck.cs
+++ b/samples/DresscaCMS/src/DresscaCMS.Authentication/Infrastructures/AuthenticationDbContextHealthCheck.cs
@@ -43,7 +43,7 @@ internal class AuthenticationDbContextHealthCheck : IHealthCheck
                 logLevel: LogLevel.Warning,
                 exception: ex,
                 message: Messages.FailedDatabaseHealthCheck);
-            return new HealthCheckResult(context.Registration.FailureStatus, exception: ex);
+            return new HealthCheckResult(context.Registration.FailureStatus);
         }
     }
 }

--- a/samples/DresscaCMS/src/DresscaCMS.Authentication/Infrastructures/HealthChecksBuilderExtensions.cs
+++ b/samples/DresscaCMS/src/DresscaCMS.Authentication/Infrastructures/HealthChecksBuilderExtensions.cs
@@ -1,0 +1,56 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using DresscaCMS.Authentication.Resources;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
+
+namespace DresscaCMS.Authentication.Infrastructures;
+
+/// <summary>
+///  <see cref="IHealthChecksBuilder"/> の拡張メソッドを提供します。
+/// </summary>
+[SuppressMessage(
+    category: "StyleCop.CSharp.ReadabilityRules",
+    checkId: "SA1101:PrefixLocalCallsWithThis",
+    Justification = "StyleCop bug. see: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3954")]
+public static class HealthChecksBuilderExtensions
+{
+    extension(IHealthChecksBuilder builder)
+    {
+        /// <summary>
+        ///  <see cref="AuthenticationDbContext"/> のヘルスチェックを追加します。
+        /// </summary>
+        /// <param name="name">ヘルスチェックの名称。</param>
+        /// <param name="failureStatus">ヘルスチェックが失敗した場合の<see cref="HealthStatus"/> 。</param>
+        /// <param name="tags">ヘルスチェックのタグ。</param>
+        /// <param name="logLevel">ログレベル。</param>
+        /// <returns><see cref="AuthenticationDbContext"/> のヘルスチェックを実装した<see cref="IHealthChecksBuilder"/>。</returns>
+        public IHealthChecksBuilder AddAuthenticationDbContextCheck(string? name = null, HealthStatus? failureStatus = default, IEnumerable<string>? tags = default, LogLevel logLevel = LogLevel.Warning)
+        {
+            return builder.AddDbContextCheck<AuthenticationDbContext>(
+            name,
+            failureStatus,
+            tags,
+            async (context, token) =>
+            {
+                try
+                {
+                    await context.Database.ExecuteSqlRawAsync("SELECT 1", token);
+                    return true;
+                }
+                catch (Exception ex)
+                {
+                    var loggerFactory = builder.Services.BuildServiceProvider().GetRequiredService<ILoggerFactory>();
+                    var logger = loggerFactory.CreateLogger("DresscaCMS.Authentication.Infrastructures.HealthChecksBuilderExtensions");
+                    logger.Log(
+                        eventId: Events.FailedDatabaseHealthCheck,
+                        logLevel: logLevel,
+                        exception: ex,
+                        message: Messages.FailedDatabaseHealthCheck);
+                    return false;
+                }
+            });
+        }
+    }
+}

--- a/samples/DresscaCMS/src/DresscaCMS.Authentication/Infrastructures/HealthChecksBuilderExtensions.cs
+++ b/samples/DresscaCMS/src/DresscaCMS.Authentication/Infrastructures/HealthChecksBuilderExtensions.cs
@@ -1,9 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
-using DresscaCMS.Authentication.Resources;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
-using Microsoft.Extensions.Logging;
 
 namespace DresscaCMS.Authentication.Infrastructures;
 
@@ -24,33 +21,13 @@ public static class HealthChecksBuilderExtensions
         /// <param name="name">ヘルスチェックの名称。</param>
         /// <param name="failureStatus">ヘルスチェックが失敗した場合の<see cref="HealthStatus"/> 。</param>
         /// <param name="tags">ヘルスチェックのタグ。</param>
-        /// <param name="logLevel">ログレベル。</param>
         /// <returns><see cref="AuthenticationDbContext"/> のヘルスチェックを実装した<see cref="IHealthChecksBuilder"/>。</returns>
-        public IHealthChecksBuilder AddAuthenticationDbContextCheck(string? name = null, HealthStatus? failureStatus = default, IEnumerable<string>? tags = default, LogLevel logLevel = LogLevel.Warning)
+        public IHealthChecksBuilder AddAuthenticationDbContextCheck(string name, HealthStatus? failureStatus = default, IEnumerable<string>? tags = default)
         {
-            return builder.AddDbContextCheck<AuthenticationDbContext>(
-            name,
-            failureStatus,
-            tags,
-            async (context, token) =>
-            {
-                try
-                {
-                    await context.Database.ExecuteSqlRawAsync("SELECT 1", token);
-                    return true;
-                }
-                catch (Exception ex)
-                {
-                    var loggerFactory = builder.Services.BuildServiceProvider().GetRequiredService<ILoggerFactory>();
-                    var logger = loggerFactory.CreateLogger("DresscaCMS.Authentication.Infrastructures.HealthChecksBuilderExtensions");
-                    logger.Log(
-                        eventId: Events.FailedDatabaseHealthCheck,
-                        logLevel: logLevel,
-                        exception: ex,
-                        message: Messages.FailedDatabaseHealthCheck);
-                    return false;
-                }
-            });
+            return builder.AddCheck<AuthenticationDbContextHealthCheck>(
+                name,
+                failureStatus,
+                tags ?? []);
         }
     }
 }

--- a/samples/DresscaCMS/src/DresscaCMS.Authentication/Resources/Messages.Designer.cs
+++ b/samples/DresscaCMS/src/DresscaCMS.Authentication/Resources/Messages.Designer.cs
@@ -61,22 +61,20 @@ namespace DresscaCMS.Authentication.Resources {
         }
         
         /// <summary>
+        ///   データベースのヘルスチェックが失敗しました。 に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        internal static string FailedDatabaseHealthCheck {
+            get {
+                return ResourceManager.GetString("FailedDatabaseHealthCheck", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   {0} 接続文字列を構成から取得できません。 に類似しているローカライズされた文字列を検索します。
         /// </summary>
         internal static string NotFoundConnectionString {
             get {
                 return ResourceManager.GetString("NotFoundConnectionString", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   データベースのヘルスチェックが失敗しました。 に類似しているローカライズされた文字列を検索します。
-        /// </summary>
-        internal static string FailedDatabaseHealthCheck
-        {
-            get
-            {
-                return ResourceManager.GetString("FailedDatabaseHealthCheck", resourceCulture);
             }
         }
     }

--- a/samples/DresscaCMS/src/DresscaCMS.Authentication/Resources/Messages.Designer.cs
+++ b/samples/DresscaCMS/src/DresscaCMS.Authentication/Resources/Messages.Designer.cs
@@ -68,5 +68,16 @@ namespace DresscaCMS.Authentication.Resources {
                 return ResourceManager.GetString("NotFoundConnectionString", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   データベースのヘルスチェックが失敗しました。 に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        internal static string FailedDatabaseHealthCheck
+        {
+            get
+            {
+                return ResourceManager.GetString("FailedDatabaseHealthCheck", resourceCulture);
+            }
+        }
     }
 }

--- a/samples/DresscaCMS/src/DresscaCMS.Authentication/Resources/Messages.resx
+++ b/samples/DresscaCMS/src/DresscaCMS.Authentication/Resources/Messages.resx
@@ -119,6 +119,7 @@
   </resheader>
   <data name="NotFoundConnectionString" xml:space="preserve">
     <value>{0} 接続文字列を構成から取得できません。</value>
+  </data>
   <data name="FailedDatabaseHealthCheck" xml:space="preserve">
     <value>データベースのヘルスチェックが失敗しました。</value>
   </data>

--- a/samples/DresscaCMS/src/DresscaCMS.Authentication/Resources/Messages.resx
+++ b/samples/DresscaCMS/src/DresscaCMS.Authentication/Resources/Messages.resx
@@ -119,5 +119,7 @@
   </resheader>
   <data name="NotFoundConnectionString" xml:space="preserve">
     <value>{0} 接続文字列を構成から取得できません。</value>
+  <data name="FailedDatabaseHealthCheck" xml:space="preserve">
+    <value>データベースのヘルスチェックが失敗しました。</value>
   </data>
 </root>

--- a/samples/DresscaCMS/src/DresscaCMS.Web/Program.cs
+++ b/samples/DresscaCMS/src/DresscaCMS.Web/Program.cs
@@ -1,4 +1,5 @@
 ﻿using DresscaCMS.Announcement;
+using DresscaCMS.Announcement.Infrastructures;
 using DresscaCMS.Authentication;
 using DresscaCMS.Authentication.Infrastructures;
 using DresscaCMS.Web.Components;
@@ -68,6 +69,11 @@ builder.Services.AddCascadingAuthenticationState();
 builder.Services.AddScoped<IdentityRedirectManager>();
 builder.Services.AddScoped<AuthenticationStateProvider, IdentityRevalidatingAuthenticationStateProvider>();
 
+// ヘルスチェックサービスを追加する
+builder.Services.AddHealthChecks()
+    .AddAnnouncementDbContextCheck("AnnoucementDatabaseHealthCheck")
+    .AddAuthenticationDbContextCheck("AuthenticationDatabaseHealthCheck");
+
 var app = builder.Build();
 
 if (app.Environment.IsDevelopment())
@@ -101,5 +107,8 @@ app.MapRazorComponents<App>()
 
 // HTTP レスポンスヘッダーにセキュリティ関連の設定を追加するミドルウェアを使用
 app.UseSecuritySettings();
+
+// ヘルスチェック API のエンドポイントをマッピングする
+app.MapHealthChecks("/health");
 
 app.Run();

--- a/samples/DresscaCMS/src/DresscaCMS.Web/Program.cs
+++ b/samples/DresscaCMS/src/DresscaCMS.Web/Program.cs
@@ -71,7 +71,7 @@ builder.Services.AddScoped<AuthenticationStateProvider, IdentityRevalidatingAuth
 
 // ヘルスチェックサービスを追加する
 builder.Services.AddHealthChecks()
-    .AddAnnouncementDbContextCheck("AnnoucementDatabaseHealthCheck")
+    .AddAnnouncementDbContextCheck("AnnouncementDatabaseHealthCheck")
     .AddAuthenticationDbContextCheck("AuthenticationDatabaseHealthCheck");
 
 var app = builder.Build();

--- a/samples/DresscaCMS/src/DresscaCMS.Web/appsettings.Development.json
+++ b/samples/DresscaCMS/src/DresscaCMS.Web/appsettings.Development.json
@@ -6,6 +6,7 @@
       "Microsoft.AspNetCore.HttpLogging": "Warning",
       "Microsoft.AspNetCore.SignalR": "Information",
       "Microsoft.AspNetCore.Http.Connections": "Information",
+      "Microsoft.Extensions.Diagnostics.HealthChecks": "Debug",
       "DresscaCMS": "Debug"
     }
   },


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## この Pull request で実施したこと

- Dressca CMS にヘルスチェック API を追加しました。
    - /health にアクセスすることで、アプリケーションの起動および、 Annoucement データベース、 Authentication データベースの応答を確認できます。
    - `ILogger` のインスタンスを取得する都合上、`IHealthChecksBuilder.AddDbContextCheck<T>` ではなく、 `IHealthChecksBuilder.AddCheck<T>`でヘルスチェックを実装しています。

## この Pull request では実施していないこと
- DatabaseHealthCheckTest は未実装です。
- Dressca のヘルスチェックAPIの修正、ドキュメントの変更は別 PR で実施します。

## Issues や Discussions 、関連する Web サイトなどへのリンク

なし

<!-- I want to review in Japanese. -->