### PR TITLE
パイプライン上での npm ci 実行時のライフサイクルスクリプト実行を無効にする

### DIFF
--- a/.github/workflows/lint-documents/action.yml
+++ b/.github/workflows/lint-documents/action.yml
@@ -13,7 +13,7 @@ runs:
 
     - name: npm パッケージのインストール
       shell: bash
-      run: npm ci
+      run: npm ci --ignore-scripts
 
     - name: Python のセットアップ
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0

--- a/.github/workflows/samples-azure-ad-b2c-auth-ci.yml
+++ b/.github/workflows/samples-azure-ad-b2c-auth-ci.yml
@@ -41,7 +41,7 @@ jobs:
           cache: npm
 
       - name: node パッケージのインストール
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - id: run-format-root
         name: ルート直下の format の実行

--- a/.github/workflows/samples-dressca-admin-frontend.ci.yml
+++ b/.github/workflows/samples-dressca-admin-frontend.ci.yml
@@ -33,7 +33,7 @@ jobs:
           # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
           cache: npm
       - name: node パッケージのインストール
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - id: run-lint
         name: lintの実行

--- a/.github/workflows/samples-dressca-consumer-frontend.ci.yml
+++ b/.github/workflows/samples-dressca-consumer-frontend.ci.yml
@@ -33,7 +33,7 @@ jobs:
           # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
           cache: npm
       - name: node パッケージのインストール
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - id: run-lint
         name: lintの実行

--- a/.github/workflows/samples-dressca-root-frontend-ci.yml
+++ b/.github/workflows/samples-dressca-root-frontend-ci.yml
@@ -32,7 +32,7 @@ jobs:
           # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
           cache: npm
       - name: node パッケージのインストール
-        run: npm ci
+        run: npm ci --ignore-scripts
       - id: run-format
         name: format の実行
         run: npm run format:ci:root >> /var/tmp/format-result.txt 2>&1

--- a/.github/workflows/samples-external-id-for-spa-ci.yml
+++ b/.github/workflows/samples-external-id-for-spa-ci.yml
@@ -41,7 +41,7 @@ jobs:
           cache: npm
 
       - name: node パッケージのインストール
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - id: run-format-root
         name: ルート直下の format の実行


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## この Pull request で実施したこと
- ライフサイクルスクリプト経由で発火するマルウェアが混入した場合に発火を防ぎます。

- ignore-scripts をした場合に、 cypress と esbuild が正常に動作しなくなる可能性がありますが、cypress はパイプラインで実行しておらず esbuild も開発環境で TS をそのまま実行するためにしか使っていないはずなので、パイプラインに限って言えば動作は問題ないはずです。

## Issues や Discussions 、関連する Web サイトなどへのリンク

https://blog.flatt.tech/entry/bitwarden_compromise#Lifecycle-script-%E3%81%AE%E7%84%A1%E5%8A%B9%E5%8C%96

esbuild もわずかにパフォーマンスが劣化しますが動作します。
また、開発環境でしか使わないので動かなくても問題ありません。
https://zenn.dev/aminevsky/articles/706f8f983cceed

<!-- I want to review in Japanese. -->