### PR TITLE
System.Security.Cryptography.Xml を更新

### DIFF
--- a/samples/DresscaCMS/Directory.Packages.props
+++ b/samples/DresscaCMS/Directory.Packages.props
@@ -1,10 +1,13 @@
 ﻿<Project>
+  <PropertyGroup>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
+  </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="bunit" Version="2.6.2" />
     <PackageVersion Include="Maris.ComponentModel.Annotations" Version="2.1.0" />
     <PackageVersion Include="Maris.Core" Version="2.1.0" />
     <PackageVersion Include="Maris.Logging.Testing" Version="2.1.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Identity" Version="2.3.9" />
+    <PackageVersion Include="Microsoft.AspNetCore.Identity" Version="2.3.10" />
     <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.5" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="10.0.5" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
@@ -18,6 +21,7 @@
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="8.0.3" />
   </ItemGroup>
   <ItemGroup>
     <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />

--- a/samples/DresscaCMS/Directory.Packages.props
+++ b/samples/DresscaCMS/Directory.Packages.props
@@ -7,7 +7,7 @@
     <PackageVersion Include="Maris.ComponentModel.Annotations" Version="2.1.0" />
     <PackageVersion Include="Maris.Core" Version="2.1.0" />
     <PackageVersion Include="Maris.Logging.Testing" Version="2.1.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Identity" Version="2.3.10" />
+    <PackageVersion Include="Microsoft.AspNetCore.Identity" Version="2.3.9" />
     <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.5" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="10.0.5" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.5" />


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## この Pull request で実施したこと

- Microsoft.AspNetCore.Identity が推移的に参照するパッケージに脆弱性があるため、更新しました。
  - System.Security.Cryptography.Xml 8.0.2 -> 8.0.3

## この Pull request では実施していないこと

現時点の Microsoft.AspNetCore.Identity 最新バージョンで脆弱性のあるパッケージが参照されているため、暫定的にSystem.Security.Cryptography.Xmlのバージョンを上書きしています。

以下PRでバージョンを上書きしないように修正予定
https://github.com/AlesInfiny/maris/issues/5532

## Issues や Discussions 、関連する Web サイトなどへのリンク

なし

<!-- I want to review in Japanese. -->