### PR TITLE
MkDocs の GitHub コード取得時の 429/404 エラーに対応

### DIFF
--- a/documents/contents/guidebooks/how-to-develop/csr/vue-js/input-validation.md
+++ b/documents/contents/guidebooks/how-to-develop/csr/vue-js/input-validation.md
@@ -32,7 +32,7 @@ https://github.com/AlesInfiny/maris/blob/main/samples/Dressca/dressca-frontend/c
 [アーキテクチャ定義](../../../../app-architecture/client-side-rendering/frontend-architecture.md#project-structure) では設定ファイルは `./src/config` フォルダーに集約されるため、ファイル `./src/config/yup.config.ts` を作成し、以下のように記述します。
 
 ```typescript title="yup.config.ts"
-https://github.com/AlesInfiny/maris/blob/main/samples/Dressca/dressca-frontend/consumer/src/config/yup.config.ts
+https://github.com/AlesInfiny/maris/blob/main/samples/Dressca/dressca-frontend/consumer/src/validation/zod-settings.ts
 ```
 
 作成したファイルを読み込むため、 入力値を検証する Vue ファイルのスクリプト構文に以下を記述します。

--- a/documents/hooks/github_markdown_fetcher.py
+++ b/documents/hooks/github_markdown_fetcher.py
@@ -1,10 +1,36 @@
 import re
+import time
+import urllib.error
 import urllib.request
+
+MAX_RETRIES = 3
+TIMEOUT_SECONDS = 10
+
+
+def fetch_url(url):
+    for attempt in range(MAX_RETRIES + 1):
+        try:
+            with urllib.request.urlopen(url, timeout=TIMEOUT_SECONDS) as response:
+                return response.read().decode('utf-8')
+        except urllib.error.HTTPError as error:
+            if error.code != 429 or attempt == MAX_RETRIES:
+                raise RuntimeError(f"Failed to fetch GitHub markdown: {url}") from error
+
+            retry_after = error.headers.get('Retry-After')
+            try:
+                wait_seconds = int(retry_after) if retry_after else 2 ** attempt
+            except ValueError:
+                wait_seconds = 2 ** attempt
+
+            time.sleep(wait_seconds)
+        except urllib.error.URLError as error:
+            raise RuntimeError(f"Failed to fetch GitHub markdown: {url}") from error
+
 
 def replacer(match):
     filename = f"{match.group('filename')}.{match.group('extension')}"
     url = f"https://raw.githubusercontent.com/{match.group('user')}/{filename}"
-    code = urllib.request.urlopen(url).read().decode('utf-8')
+    code = fetch_url(url)
     spacing = match.group('spacing')
     
     # begin と end が整数に変換できるかどうかをチェック


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## この Pull request で実施したこと

MkDocs のビルド時に GitHub 上の Markdown / コード参照を取得する処理で、GitHub から HTTP 429 が返された場合にリトライするようにしました。

また、存在しない `yup.config.ts` を参照していたドキュメント内の GitHub リンクを、存在する `zod-settings.ts` へのリンクに修正しました。

## この Pull request では実施していないこと

入力値検証に関するドキュメント本文の内容は修正していません。

現在のドキュメント本文には yup を前提とした説明が残っていますが、本 Pull request では CI の失敗対応のみを目的としているため、Zod 前提の説明への更新は別 Pull request で実施します。

## Issues や Discussions 、関連する Web サイトなどへのリンク

なし

<!-- I want to review in Japanese. -->