### PR TITLE
System.Security.Cryptography.Xml パッケージのバージョンを脆弱でないものへオーバーライドする

### DIFF
--- a/samples/DresscaCMS/Directory.Packages.props
+++ b/samples/DresscaCMS/Directory.Packages.props
@@ -21,7 +21,7 @@
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
-    <PackageVersion Include="System.Security.Cryptography.Xml" Version="8.0.3" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="8.0.4" />
   </ItemGroup>
   <ItemGroup>
     <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## この Pull request で実施したこと

脆弱性を持つパッケージ System.Security.Cryptography.Xml への推移的依存関係を持つ
[Microsoft.AspNetCore.Identity](https://github.com/dotnet/aspnetcore) が、 PR作成時点の最新版 2.3.11  において、下図の通り脆弱なバージョンを参照しているため、オーバーライドを継続します。
<img width="572" height="517" alt="image" src="https://github.com/user-attachments/assets/3fa0cb45-9044-45df-8d55-83d63aecac48" />

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

- https://github.com/AlesInfiny/maris/issues/5532
<!-- I want to review in Japanese. -->